### PR TITLE
Add CONTRIBUTING guidelines for all tektoncd projects ✔️

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing to the community repo
+
+Thank you for your interest in contributing!
+
+This doc is about how to contribute to this repo specifically. For how to
+contribute to tektoncd projects in general, see [the overview in our README](README.md)
+and the individual `CONTRIBUTING.md` files in each respective project.
+
+**All contributors must comply with
+[the code of conduct](./code-of-conduct.md).**
+
+This repo contains documentation about interacting with the community as well as standard
+and processes that apply to all repos in `tektoncd`. PRs are welcome, and will follow
+[the tektoncd pull request process](process.md#pull-request-process).
+
+The [OWNERS](OWNERS) of this repo are the [members of the Tekton governing board](goverance.md).
+Any substantial changes to the policies in this repo should be reviewed by at least 50% of the
+governing board.

--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,8 @@
-
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
 - bobcatfish
 - dlorenc
-- ImJasonH
 - vdemeester
+- kimsterv
+- abayer

--- a/README.md
+++ b/README.md
@@ -2,4 +2,30 @@
 
 This is the central home for documentation on joining and contributing to the Tekton community.
 
-To learn more about how the project works, see [Governance](governance.md).
+## Want to learn how the project works
+
+* Take a look at [our Governance docs](governance.md)
+
+## Want to get involved
+
+[Reach out](contact.md) via:
+
+* [slack](contact.md#slack)
+* [our mailing list](contact.md#mailing-list)
+* [our working group](contact.md#working-group)
+
+See our standards regarding:
+
+* [Code of conduct](code-of-conduct.md)
+* [Development principles](standards.md#principles)
+* [Commit messages](standards.md#commit-messages)
+* [Go coding standards](standard.md#go)
+
+Find out about our processes:
+
+* [Find something to work on](process.md#finding-something-to-work-on)
+* [Propose features](process.md#proposing-features)
+* [Project OWNERS](process.md#OWNERS)
+* [Pull request reviews](process.md#reviews)
+
+_For guidelines on how to contribute to `tektoncd/community` see [CONTRIBUTING.md](CONTRIBUTING.md)._

--- a/contact.md
+++ b/contact.md
@@ -1,0 +1,35 @@
+# Contact the Tekton Community
+
+We are so happy you want to get in touch! You can reach and join us via:
+
+* [Slack](#slack)
+* [Our mailing list](#mailing-list)
+* [The Tekton working group](#working-group)
+
+## Slack
+
+We can be reached on slack at
+[`#build-pipeline`](https://knative.slack.com/messages/build-pipeline)!
+
+(We were formerly part of [the knative project](github.com/knative)) and they
+are kindly letting us continue to use their slack until we get our own!)
+
+## Mailing List
+
+Our mailing list is
+[tekton-dev@](https://groups.google.com/forum/#!forum/tekton-dev).
+
+All docs which are shared with the Tekton community (including
+[working group](#working-group) meeting recordings!) are made visible to this group,
+so please join if you are interested in accessing those docs.
+
+## Working Group
+
+The Tekton working group meets
+[at 9am PST on Tuesdays](https://calendar.google.com/event?action=TEMPLATE&tmeid=amZyNTljOWpkZWdibmpsY3JlazNodDU5NWdfMjAxOTAzMjZUMTYwMDAwWiBnb29nbGUuY29tX2Qzb3Zjdm8xcDMyMTloOTg5NTczdjk4Zm5zQGc&tmsrc=google.com_d3ovcvo1p3219h989573v98fns%40group.calendar.google.com&scp=ALL).
+
+Everyone is welcome!
+
+Recordings are made and posted in
+[the meeting minutes](https://docs.google.com/document/d/1rPR7m1Oj0ip3bpd_bcS1sjZyPgGi_g9asF5YrExeESc).
+This doc and the recordings themselves are visible to [all members of our mailing list](#mailing-list).

--- a/governance.md
+++ b/governance.md
@@ -33,13 +33,13 @@ The committee will be responsible for a series of specific artifacts and activit
 ### Initial Charter
 
 This document will define how the committee is to manage the project until it has transitioned to an elected steering body, as well as what governance must be in place.
-The Kubernetes Steering Committee Charter Draft serves as a good example. 
+The Kubernetes Steering Committee Charter Draft serves as a good example.
 
 A charter should cover all of the following topics:
 
 * Scope of rights and responsibilities explicitly held by the committee
 * Committee structure that meets the requirements above
-* Election process, including: 
+* Election process, including:
   * special elections in the case someone resigns or is impeached
   * who is eligible to nominate candidates and how
   * who is eligible to run as a candidate
@@ -60,22 +60,24 @@ A charter should cover all of the following topics:
 ## Transition Process
 
 The transition process MUST:
-  * Organize, execute, and validate an election for replacing bootstrap members (they may re-run, but would need to be re-elected in order to stay)
-  * Define the term lengths for newly-elected individuals, ideally so not all members change out at once
-  * Provide documentation for the community and committee members sufficient to smoothly continue the established practices of the committee
+
+* Organize, execute, and validate an election for replacing bootstrap members (they may re-run, but would need to be re-elected in order to stay)
+* Define the term lengths for newly-elected individuals, ideally so not all members change out at once
+* Provide documentation for the community and committee members sufficient to smoothly continue the established practices of the committee
 
 ## Contribution Process
 
 The committee MUST define a contribution process that:
-  * Explains to potential contributors how/if they can add code to the repository/repositories
-  * Documents Workflow and management of pull requests
-  * Identifies who is authorized to commit or revert code
-  * Identifies automation is required for normal operations
-  * Defines how release decisions are made
-    * Who is authorized to release and when.
-    * Frequency limits
-  * Defines the documentation process
-  * Defines what CLA process is required and how it is programmatically enforced before code is merged
+
+* Explains to potential contributors how/if they can add code to the repository/repositories
+* Documents Workflow and management of pull requests
+* Identifies who is authorized to commit or revert code
+* Identifies automation is required for normal operations
+* Defines how release decisions are made
+  * Who is authorized to release and when.
+  * Frequency limits
+* Defines the documentation process
+* Defines what CLA process is required and how it is programmatically enforced before code is merged
 
 ## Code of Conduct
 
@@ -83,6 +85,6 @@ The code of conduct MUST set expectations for contributors on expected behavior,
 The [Contributor Covenant](https://www.contributor-covenant.org) has become the de facto standard for this language.
 
 ## Project Communication Channels
+
 What are the primary communications channels the project will adopt and manage?
 This can include Slack, mailing lists, an organized Stack Overflow topic, or exist only in GitHub issues and pull requests.
-

--- a/process.md
+++ b/process.md
@@ -1,0 +1,149 @@
+# Tekton project processes
+
+This doc explains general development processes that apply to all projects
+within the org. Individual projects may have their own processes as well,
+which you can find documented in their individual `CONTRIBUTING.md` files.
+
+* [Finding something to work on](#finding-something-to-work-on)
+* [Proposing features](#proposing-features)
+* [Project OWNERS](#OWNERS)
+* Pull request [reviews](#reviews) and [process](#pull-request-process)
+
+## Finding something to work on
+
+Thanks so much for considering contributing to our project!! We hope very much
+you can find something interesting to work on:
+
+* To find issues that we particularly would like contributors to tackle, look
+  for issues with the `help wanted` label
+* Issues that are good for new folks will additionally be marked with
+  `good first issue`
+
+### Assigning yourself an issue
+
+To assign an issue to a user (or yourself), use GitHub or the Prow command by
+writing a comment in the issue such as:
+
+```none
+/assign @your_github_username
+```
+
+Unfortunately, GitHub will only allow issues to be assigned to users who are
+["collaborators"](https://developer.github.com/v3/repos/collaborators/),
+aka anyone in [the tektoncd org](https://github.com/orgs/tektoncd/people) and/or collaborators
+added to the repo itself.
+
+But don't let that stop you! **Leave a comment in the issue indicating you would
+like to work on it** and we will consider it assigned to you.
+
+### Contributor SLO
+
+If you declare your intention to work on an issue:
+
+* If it becomes urgent that the issue be resolved (e.g. critical bug or nearing
+  the end of a milestone), someone else may take over (apologies if this happens!!)
+* If you do not respond to queries on an issue within approximately **3 days** and
+  someone else wants to work on your issue, we will assume you are no longer interested
+  in working on it and it is fair game to assign to someone else (no worries at
+  all if this happens, we don't mind!)
+
+## Proposing features
+
+If you have an idea for a feature, or if you have a solution for an existing
+issue that involves an API change, we highly suggest that you propose the
+changes before implementing them.
+
+This is for two main reasons:
+
+1. [Yes is forever](https://twitter.com/solomonstre/status/715277134978113536)
+2. It's easier/cheaper to make changes before implementation (and you'll feel
+   less emotionally invested!)
+
+Some suggestions for how to do this:
+
+1. Write up a design doc and share it with [the mailing list](contact.md#mailing-list)
+2. Bring your design/ideas to [our working group meetings](contact.md#working-group) for
+   discussion
+
+A great proposal will include:
+
+* **The use case(s) it solves** Who needs this and why?
+* **Requirements** What needs to be true about the solution?
+* **2+ alternative proposals** Even if alternatives aren't obvious, forcing
+  yourself to brainstorm a couple more approaches may give you new ideas or make
+  clear that your initial proposal is the best one
+
+Also feel free to reach out to us on [slack](contact.md#slack) if you want any
+help/guidance.
+
+Thanks so much!!
+
+## OWNERS
+
+Our contributors are made up of:
+
+* A core group of OWNERS (defined in `OWNERS` files)) who can
+  [approve PRs](#getting-sign-off)
+* Any and all other contributors!
+
+If you are interested in becoming an OWNER of a project, take a look at the
+[requirements](#requirements) and follow up with an existing OWNER
+[on slack](#contact).
+
+### Requirements
+
+To be added as an OWNER of a project, you must:
+
+* Have been actively participating in reviews for at least 3 months or
+  50% of the project lifetime, whichever is shorter
+* Have been the primary reviewer for at least 10 substantial PRs to the codebase.
+* Have reviewed at least 30 PRs to the codebase.
+* Be nominated by another OWNER (with no objections from other OWNERS)
+
+The final change will be made via a PR to update the OWNERS file.
+
+## Reviews
+
+Reviewers will be auto-assigned by [Prow](#pull-request-process) from the
+[OWNERS](#OWNERS), which acts as suggestions for which `OWNERS` should
+review the PR. (OWNERS, your review requests can be viewed at
+[https://github.com/pulls/review-requested](https://github.com/pulls/review-requested)).
+
+### Pull request process
+
+Tekton repos use [Prow](https://github.com/kubernetes/test-infra/tree/master/prow)
+and related tools like
+[Tide](https://github.com/kubernetes/test-infra/tree/master/prow/tide) and
+[Gubernator](https://github.com/kubernetes/test-infra/tree/master/gubernator).
+This means that automation will be applied to your pull requests.
+
+The configuration for this automation is in [`tektoncd/plumbing`](https://github.com/tektoncd/plumbing).
+
+_More on the Prow process in general
+[is available in the k8s docs](https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md#the-code-review-process)._
+
+#### Prow commands
+
+Prow has a [number of commands](https://prow.tekton.dev/command-help) you can
+use to interact with it.
+
+Before a PR can be merged, it must have both `/lgtm` AND `/approve`:
+
+* `/lgtm` can be added by ["collaborators"](https://developer.github.com/v3/repos/collaborators/),
+  aka anyone in [the tektoncd org](https://github.com/orgs/tektoncd/people) and/or collaborators
+  added to the repo itself
+* `/approve` can be added only by [OWNERS](#owners)
+
+[OWNERS](#owners) automatically get `/approve` but still will need an `/lgtm` to merge.
+
+The merge will happen automatically once the PR has both `/lgtm` and `/approve`,
+and all tests pass. If you don't want this to happen you should
+[`/hold`](#preventing-the-merge) the PR.
+
+Any changes will cause the `/lgtm` label to be removed and it will need to be
+re-applied.
+
+If you are not a [collaborator](https://developer.github.com/v3/repos/collaborators/),
+you will need a collaborator to add `/ok-to-test` to your PR to allow tests to run.
+
+(But most importantly you can add dog and cat pictures to PRs with `/woof` and `/meow`!!)

--- a/standards.md
+++ b/standards.md
@@ -1,0 +1,47 @@
+# Tekton Development Standards
+
+This doc contains the standards we try to uphold across all project
+in the Tekton org.
+
+## Principles
+
+When possbile, try to practice:
+
+- **Documentation driven development** - Before implementing anything, write
+  docs to explain how it will work
+- **Test driven development** - Before implementing anything, write tests to
+  cover it
+
+Minimize the number of integration tests written and maximize the unit tests!
+Unit test coverage should increase or stay the same with every PR.
+
+This means that most PRs should include both:
+
+1. Tests
+2. Documentation updates
+
+## Commit Messages
+
+All commit messages should follow
+[these best practices](https://chris.beams.io/posts/git-commit/), specifically:
+
+- Start with a subject line
+- Contain a body that explains _why_ you're making the change you're making
+- Reference an issue number one exists, closing it if applicable (with text such
+  as
+  ["Fixes #245" or "Closes #111"](https://help.github.com/articles/closing-issues-using-keywords/))
+
+Aim for [2 paragraphs in the body](https://www.youtube.com/watch?v=PJjmw9TRB7s).
+Not sure what to put? Include:
+
+- What is the problem being solved?
+- Why is this the best approach?
+- What other approaches did you consider?
+- What side effects will this approach have?
+- What future work remains to be done?
+
+## Coding standards
+
+### Go
+
+- [Go code review comments](https://github.com/golang/go/wiki/CodeReviewComments)


### PR DESCRIPTION
This takes the contributing guidelines from
https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md
and generalizes (and updates) them to apply to all projects in the
tektoncd org.

Following up to this, I will remove most of the content of
https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md
and link to this community repo instead.

Some new things:

* The guidelines on becoming an OWNERS are adapted from https://github.com/knative/docs/blob/master/contributing/ROLES.md#approver
* I changed the OWNERS file to contain the members of the governing
  board
* I arbitrarily said that 50% of the governing board should review
  PRs in this repo that change policy

Fixes #1 Fixes #3

p.s. Shout out to the person who came up to me yesterday and was so sad
that we had no contributing guidelines b/c he went straight to the
community repo and there was nothing there!! Very motivating moment for
me XD