### PR TITLE
Create Tekton mailing list for code of conduct issues

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -56,7 +56,7 @@ further defined and clarified by project maintainers.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the project team at
-knative-code-of-conduct@googlegroups.com. All complaints will be reviewed and
+tekton-code-of-conduct@googlegroups.com. All complaints will be reviewed and
 investigated and will result in a response that is deemed necessary and
 appropriate to the circumstances. The project team is obligated to maintain
 confidentiality with regard to the reporter of an incident. Further details of

--- a/governance.md
+++ b/governance.md
@@ -84,6 +84,9 @@ The committee MUST define a contribution process that:
 The code of conduct MUST set expectations for contributors on expected behavior, as well as explaining the consequences of violating the terms of the code.
 The [Contributor Covenant](https://www.contributor-covenant.org) has become the de facto standard for this language.
 
+Members of the governance committee will be responsible for handling [Tekton code of conduct](code-of-conduct.md)
+violations via tekton-code-of-conduct@googlegroups.com.
+
 ## Project Communication Channels
 
 What are the primary communications channels the project will adopt and manage?


### PR DESCRIPTION
We were still using the group from Knative! The Tekton project will now
have its own mailing list for reporting issues, and this change proposes
that governing committee members will be responsible for responding to
reports of violations.