### PR TITLE
Move working group to Wednesdays 📅

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -26,7 +26,7 @@ so please join if you are interested in accessing those docs.
 ## Working Group
 
 The Tekton working group meets
-[at 9am PST on Tuesdays](https://calendar.google.com/event?action=TEMPLATE&tmeid=amZyNTljOWpkZWdibmpsY3JlazNodDU5NWdfMjAxOTAzMjZUMTYwMDAwWiBnb29nbGUuY29tX2Qzb3Zjdm8xcDMyMTloOTg5NTczdjk4Zm5zQGc&tmsrc=google.com_d3ovcvo1p3219h989573v98fns%40group.calendar.google.com&scp=ALL).
+[at 9am PST on Wednesdays](https://calendar.google.com/event?action=TEMPLATE&tmeid=bjc0aWJqMzVtYm04ZWt2NHJlajJmajdvNGtfMjAxOTA1MjlUMTYwMDAwWiBnb29nbGUuY29tX2Qzb3Zjdm8xcDMyMTloOTg5NTczdjk4Zm5zQGc&tmsrc=google.com_d3ovcvo1p3219h989573v98fns%40group.calendar.google.com&scp=ALL).
 
 Everyone is welcome!
 


### PR DESCRIPTION
In a recent working group meeting, it was brought up that the CDF TOC
meeting overlapped with the Tekton Working group meeting (which has been
on Tuesdays at 9am PST) so I sent around a form and the most popular
option to move the meeting to is Wednesdays at 9am PST so let's try that
for a while.

This commit updates the info and posts a new link to the calendar event
which should now be on Wednesdays.

Relevant thread on the mailing list:
https://groups.google.com/forum/#!topic/tekton-dev/MlUfUJU-7N8