### PR TITLE
Update docs on changes to project access resources 👮

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -98,5 +98,18 @@ Members of the governing board will be given access to these resources:
 
 * [The GCP project `tekton-releases`](http://console.cloud.google.com/home/dashboard?project=tekton-releases)
   which is used for [test and release infrastructure](https://github.com/tektoncd/plumbing)
-* [The GCP projects](https://github.com/tektoncd/plumbing/blob/master/boskos/boskos-config.yaml)
-  used by [boskos](https://github.com/tektoncd/plumbing#boskos)
+* [The GCP project `tekton-nightly`](http://console.cloud.google.com/home/dashboard?project=tekton-nightly)
+  which is used for publishing nightly releases for Tekton projects
+
+They have the following permissions:
+
+* `Project Viewer` - To see the project in the web UI
+* `Kubernetes Engine Admin` - To create and use GKE clusters
+* `Storage Admin` - To push to GCS buckets and GCR
+
+At the moment access to
+[the GCP projects](https://github.com/tektoncd/plumbing/blob/master/boskos/boskos-config.yaml)
+used by [boskos](https://github.com/tektoncd/plumbing#boskos) is limited to members of the
+Governing board from Google. In [plumbing #34](https://github.com/tektoncd/plumbing/issues/34)
+we will reduce the number of projects we need to manage and ensure all governing members have
+access.


### PR DESCRIPTION
Unfortunately since the resources we are currently using for our
infrastructure are Google resources, we couldn't just give all governing
board members owner access too all the projects we are using. In the
long run we probably want to change this so that the infrastructure is
billed to the CDF, but in the short term we've scaled back the
permissions and are trying to pinpoint exactly the right set to make
sure ppl can do what they need to do.

I also tried to add these permissions to all the boskos projects but
there are about to be 14 of them
(https://github.com/tektoncd/plumbing/issues/29) and it turns out to be
super tedious to apply these individual permissions across 14 different
projects - and they can't share roles. So I decided to keep it simple
and not give everyone access to the boskos projects for now (especially
since afaik no one has ever needed to interact with them directly) and
to open https://github.com/tektoncd/plumbing/issues/34 about finding a
way to not need 16+ different projects with their own permissions - as
long as this is okay with the non-Google governing folks! If it isn't
I'll add the permissions to all the projects.