### PR TITLE
Add link to shared doc drive 📁

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ This is the central home for documentation on joining and contributing to the Te
 
 ## Want to get involved
 
-[Reach out](contact.md) via:
+[Reach out](contact.md) and see what we're up to via:
 
 * [slack](contact.md#slack)
 * [our mailing list](contact.md#mailing-list)
 * [our working group](contact.md#working-group)
+* [our shared document drive](contact.md#shared-drive)
 
 See our standards regarding:
 

--- a/contact.md
+++ b/contact.md
@@ -39,3 +39,10 @@ Everyone is welcome!
 Recordings are made and posted in
 [the meeting minutes](https://docs.google.com/document/d/1rPR7m1Oj0ip3bpd_bcS1sjZyPgGi_g9asF5YrExeESc).
 This doc and the recordings themselves are visible to [all members of our mailing list](#mailing-list).
+
+## Shared Drive
+
+As much as we can we try to add community docs to
+[our shared Google drive](https://drive.google.com/drive/u/0/folders/0AFOvPxM9MpebUk9PVA).
+Anyone who joins [the mailing list](#mailing-list) will be able to add and edit files in this drive,
+which includes design docs and and our [working group](#working-group) recordings.


### PR DESCRIPTION
This shared drive has been where we've been putting meeting group
recordings all this time but we haven't yet been using it for other
docs. Folks have been asking more and more recently for something like
this so now the drive should be editable by folks on the mailing list
and we can try to making design docs and meeting notes available here
when possible.

+ @afrittoli 
+ that person who asked for this in slack like 4 months ago :(