### PR TITLE
Add calendar and triggers sync to docs 📅

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ This is the central home for documentation on joining and contributing to the Te
 
 * [slack](contact.md#slack)
 * [our mailing list](contact.md#mailing-list)
-* [our working group](contact.md#working-group)
+* [our working group](contact.md#working-group) and [other meetings](contact.md#other-meetings)
 * [our shared document drive](contact.md#shared-drive)
+* [our shared calendar](contact.md#calendar)
 
 See our standards regarding:
 

--- a/contact.md
+++ b/contact.md
@@ -29,16 +29,40 @@ All docs which are shared with the Tekton community (including
 [working group](#working-group) meeting recordings!) are made visible to this group,
 so please join if you are interested in accessing those docs.
 
+## Calendar
+
+Tekton events such as [working group](#working-group) and [other meetings](#other-meetings)
+are visible on
+[the Tekton calendar](https://calendar.google.com/calendar?cid=Z29vZ2xlLmNvbV9kM292Y3ZvMXAzMjE5aDk4OTU3M3Y5OGZuc0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t).
+
 ## Working Group
 
 The Tekton working group meets
 [at 9am PST on Wednesdays](https://calendar.google.com/event?action=TEMPLATE&tmeid=bjc0aWJqMzVtYm04ZWt2NHJlajJmajdvNGtfMjAxOTA1MjlUMTYwMDAwWiBnb29nbGUuY29tX2Qzb3Zjdm8xcDMyMTloOTg5NTczdjk4Zm5zQGc&tmsrc=google.com_d3ovcvo1p3219h989573v98fns%40group.calendar.google.com&scp=ALL).
+
+_See [the calendar](#calendar) for more events._
 
 Everyone is welcome!
 
 Recordings are made and posted in
 [the meeting minutes](https://docs.google.com/document/d/1rPR7m1Oj0ip3bpd_bcS1sjZyPgGi_g9asF5YrExeESc).
 This doc and the recordings themselves are visible to [all members of our mailing list](#mailing-list).
+
+### Other meetings
+
+Ad-hoc meetings can be announced in
+[the `#meeting` channel](https://app.slack.com/client/TJ45YV83X/CLUAVRKQA/thread/CL3T51NRF-1565213856.087600)
+in [our slack](#slack).
+
+As needed we will schedule other regularly occuring meetings. At the moment we have:
+
+* As we get the initial implementation of [Tekton Triggers](https://github.com/tektoncd/triggers) off the group,
+  we are having a meeting
+  [at 10am EST on Thursdays every 2 weeks](https://calendar.google.com/event?action=TEMPLATE&tmeid=NHRlZGVzOWxzajRzMWx1MWZlM3R2MXFqbDlfMjAxOTExMTRUMTUwMDAwWiBnb29nbGUuY29tX2Qzb3Zjdm8xcDMyMTloOTg5NTczdjk4Zm5zQGc&tmsrc=google.com_d3ovcvo1p3219h989573v98fns%40group.calendar.google.com&scp=ALL).
+  [These are the meeting minutes](https://docs.google.com/document/d/1T87yK4BIu291gGK1L2ZzDpesGCnXX3tGuWXjdr5Soxw/edit)
+  which are available in our [the shared drive](#shared-drive).
+
+_See [the calendar](#calendar) for more events._
 
 ## Shared Drive
 


### PR DESCRIPTION
We've been having some ad-hoc meetings about triggers that have been
becoming more regular as we've found more in the design to discuss, and
more folks are interested in joining these meetings, so they are now
available on the public Tekton calendar!

Also added a link to the calendar itself and to a `#meetings` channel in
slack where people can announce more ad-hoc meetings that they'd like to
invite community folks to.