### PR TITLE
Add link to beta working group meetings + agenda β

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is the central home for documentation on joining and contributing to the Te
 
 * [slack](contact.md#slack)
 * [our mailing list](contact.md#mailing-list)
-* [our working group](contact.md#working-group) and [other meetings](contact.md#other-meetings)
+* [our working group meetings](contact.md#working-groups)
 * [our shared document drive](contact.md#shared-drive)
 * [our shared calendar](contact.md#calendar)
 

--- a/contact.md
+++ b/contact.md
@@ -4,7 +4,7 @@ We are so happy you want to get in touch! You can reach and join us via:
 
 * [Slack](#slack)
 * [Our mailing list](#mailing-list)
-* [The Tekton working group](#working-group)
+* [The Tekton working group](#working-groups)
 
 ## Slack
 
@@ -35,32 +35,29 @@ Tekton events such as [working group](#working-group) and [other meetings](#othe
 are visible on
 [the Tekton calendar](https://calendar.google.com/calendar?cid=Z29vZ2xlLmNvbV9kM292Y3ZvMXAzMjE5aDk4OTU3M3Y5OGZuc0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t).
 
-## Working Group
+## Working Groups
 
-The Tekton working group meets
-[at 9am PST on Wednesdays](https://calendar.google.com/event?action=TEMPLATE&tmeid=bjc0aWJqMzVtYm04ZWt2NHJlajJmajdvNGtfMjAxOTA1MjlUMTYwMDAwWiBnb29nbGUuY29tX2Qzb3Zjdm8xcDMyMTloOTg5NTczdjk4Zm5zQGc&tmsrc=google.com_d3ovcvo1p3219h989573v98fns%40group.calendar.google.com&scp=ALL).
+There are several regular working group meetings:
 
-_See [the calendar](#calendar) for more events._
-
-Everyone is welcome!
-
-Recordings are made and posted in
-[the meeting minutes](https://docs.google.com/document/d/1rPR7m1Oj0ip3bpd_bcS1sjZyPgGi_g9asF5YrExeESc).
-This doc and the recordings themselves are visible to [all members of our mailing list](#mailing-list).
-
-### Other meetings
-
-Ad-hoc meetings can be announced in
-[the `#meeting` channel](https://app.slack.com/client/TJ45YV83X/CLUAVRKQA/thread/CL3T51NRF-1565213856.087600)
-in [our slack](#slack).
-
-As needed we will schedule other regularly occuring meetings. At the moment we have:
-
+* The working group for all of Tekton working meets:
+[at 9am PST on Wednesdays](https://calendar.google.com/event?action=TEMPLATE&tmeid=bjc0aWJqMzVtYm04ZWt2NHJlajJmajdvNGtfMjAxOTA1MjlUMTYwMDAwWiBnb29nbGUuY29tX2Qzb3Zjdm8xcDMyMTloOTg5NTczdjk4Zm5zQGc&tmsrc=google.com_d3ovcvo1p3219h989573v98fns%40group.calendar.google.com&scp=ALL). [Tekton meeting minutes](https://docs.google.com/document/d/1rPR7m1Oj0ip3bpd_bcS1sjZyPgGi_g9asF5YrExeESc).  
+* As we work toward a beta release of Tekton Pipelines, we are having a meeting
+  [at 9am EST on Mondays every 2 weeks](https://calendar.google.com/event?action=TEMPLATE&tmeid=NXRiamQwbWh1ajk0OTEyOTY0YjVzcXBnbGJfMjAxOTA5MjNUMTYwMDAwWiBnb29nbGUuY29tX2Qzb3Zjdm8xcDMyMTloOTg5NTczdjk4Zm5zQGc&tmsrc=google.com_d3ovcvo1p3219h989573v98fns%40group.calendar.google.com&scp=ALL).
+  [These are the meeting minutes](https://docs.google.com/document/d/1JmRd0vbh2Q6Emu2DOk-LwLHfxd2V0zrN4WNawGzoNXw).
 * As we get the initial implementation of [Tekton Triggers](https://github.com/tektoncd/triggers) off the group,
   we are having a meeting
   [at 10am EST on Thursdays every 2 weeks](https://calendar.google.com/event?action=TEMPLATE&tmeid=NHRlZGVzOWxzajRzMWx1MWZlM3R2MXFqbDlfMjAxOTExMTRUMTUwMDAwWiBnb29nbGUuY29tX2Qzb3Zjdm8xcDMyMTloOTg5NTczdjk4Zm5zQGc&tmsrc=google.com_d3ovcvo1p3219h989573v98fns%40group.calendar.google.com&scp=ALL).
   [These are the meeting minutes](https://docs.google.com/document/d/1T87yK4BIu291gGK1L2ZzDpesGCnXX3tGuWXjdr5Soxw/edit)
   which are available in our [the shared drive](#shared-drive).
+
+Everyone is welcome!
+
+Recordings are made and posted in the minutes of each meeting.
+These docs and the recordings themselves are visible to [all members of our mailing list](#mailing-list).
+
+Ad-hoc meetings can be announced in
+[the `#meeting` channel](https://app.slack.com/client/TJ45YV83X/CLUAVRKQA/thread/CL3T51NRF-1565213856.087600)
+in [our slack](#slack).
 
 _See [the calendar](#calendar) for more events._
 


### PR DESCRIPTION
We had our first beta working group meeting today and decided to try to
hold it every 2 weeks as we go forward toward beta to keep in touch and
see how things are going.

Now that we have 3 regular meetings, I reorganized the working group
section a bit.