### PR TITLE
More clearly document doc visibility

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -25,7 +25,7 @@ which are shared with the Tekton community (including
 [working group](#working-group) meeting recordings!) are made visible to this
 group, so please join if you are interested in accessing those docs.
 
-Our mailing list for end user of Tekton is
+Our mailing list for end users of Tekton is
 [tekton-users@](https://groups.google.com/forum/#!forum/tekton-users).
 
 ## Calendar

--- a/contact.md
+++ b/contact.md
@@ -20,14 +20,13 @@ Some important channels:
 ## Mailing List
 
 Our mailing list for developers working on Tekton is
-[tekton-dev@](https://groups.google.com/forum/#!forum/tekton-dev).
+[tekton-dev@](https://groups.google.com/forum/#!forum/tekton-dev). All docs
+which are shared with the Tekton community (including
+[working group](#working-group) meeting recordings!) are made visible to this
+group, so please join if you are interested in accessing those docs.
 
 Our mailing list for end user of Tekton is
 [tekton-users@](https://groups.google.com/forum/#!forum/tekton-users).
-
-All docs which are shared with the Tekton community (including
-[working group](#working-group) meeting recordings!) are made visible to this group,
-so please join if you are interested in accessing those docs.
 
 ## Calendar
 


### PR DESCRIPTION
Docs are shared with `tekton-dev`, and the previous wording made this unclear.

cc @jchesterpivotal
