### PR TITLE
Update Slack invite link

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -15,7 +15,8 @@ Some important channels:
 * `#admin` - Request slack related changes, e.g. proposing new channels
 * `#plumbing` - Request [infrastructure support](https://github.com/tektoncd/plumbing#support)
 
-[Use this link to join the `tektoncd` slack!](https://join.slack.com/t/tektoncd/shared_invite/enQtNjQ1NjQzNTQ3MDQwLWViNmMxYTI2ZDliMTAzZjAwNzM1OWQ4NzUwMTUzNWY3YTNlZTU4NmQyOGMwZTlmY2I5ODAzYzNmMDdiZDdjYjA) We look forward to chatting with you! 😻
+[Use this link to join the `tektoncd` slack!](https://join.slack.com/t/tektoncd/shared_invite/enQtNjQ1NjQzNTQ3MDQwLTc5MWU4ODg3MGJiYjllZjlmMWI0YWFlMzJjMTkyZGEyMTFhYzY1ZTkzZGU0M2I3NGEyYjU2YzNhOTE4OWQyZTM) We look forward to chatting with you! 😻
+
 
 ## Mailing List
 


### PR DESCRIPTION
The invite link to our slack workspace was sending people to an expired
link page.

This PR updates the link to a newly-generated, and tested in incognito,
invitation to join slack.