### PR TITLE
Update boskos access docs

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -100,16 +100,11 @@ Members of the governing board will be given access to these resources:
   which is used for [test and release infrastructure](https://github.com/tektoncd/plumbing)
 * [The GCP project `tekton-nightly`](http://console.cloud.google.com/home/dashboard?project=tekton-nightly)
   which is used for publishing nightly releases for Tekton projects
+* [The GCP projects used by boskos](https://github.com/tektoncd/plumbing/blob/master/boskos/boskos-config.yaml) which are used to test against
 
-They have the following permissions:
+They have the following permissions (added with https://github.com/tektoncd/plumbing/blob/master/addpermissions.py):
 
 * `Project Viewer` - To see the project in the web UI
 * `Kubernetes Engine Admin` - To create and use GKE clusters
 * `Storage Admin` - To push to GCS buckets and GCR
-
-At the moment access to
-[the GCP projects](https://github.com/tektoncd/plumbing/blob/master/boskos/boskos-config.yaml)
-used by [boskos](https://github.com/tektoncd/plumbing#boskos) is limited to members of the
-Governing board from Google. In [plumbing #34](https://github.com/tektoncd/plumbing/issues/34)
-we will reduce the number of projects we need to manage and ensure all governing members have
-access.
+* `ServiceAccount User` - To use service accounts


### PR DESCRIPTION
I had previously been lazy and not given everyone access to the boskos projects b/c it's not needed very often, but @vdemeester wanted access to help debug https://github.com/tektoncd/pipeline/issues/1500 so in https://github.com/tektoncd/plumbing/pull/105 I created a script to make it easy to give access to all of the 11 million boskos projects :D (and to expand the permissions if needed!)

Also added the service account permission which folks already had (to perform releases using a service account).