### PR TITLE
Remove the knative prow robot from the org.

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -40,7 +40,6 @@ members:
 - jromero
 - khrm
 - kimsterv
-- knative-prow-robot
 - Megan-Wright
 - mnuttall
 - nader-ziada


### PR DESCRIPTION
This is also a test of our automated peribolos config!