### PR TITLE
Add ameyer-pivotal to the tektoncd org!

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -21,6 +21,7 @@ members:
 - afrittoli
 - akihikokuroda
 - AlanGreene
+- ameyer-pivotal
 - carlos-logro
 - CarolynMabbott
 - chmouel


### PR DESCRIPTION
This is for https://github.com/tektoncd/catalog/pull/116, and is serving to test
the peribolos configuration. My earlier test failed because github was down and never sent the event.

If this works, I'll send another PR to add the remaning buildpacks OWNERRS from that PR.