### PR TITLE
Add user profiles link to front page 🎩

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ See our standards regarding:
 * [Development principles](standards.md#principles)
 * [Commit messages](standards.md#commit-messages)
 * [Go coding standards](standards.md#go)
+* [User profiles](user-profiles.md)
 
 Find out about our processes:
 


### PR DESCRIPTION
User profiles are very useful when trying to talk about designs and who needs what - especially since folks may wear so many different hats when interacting with Tekton! But you'd need to know this was here already to discover it so adding a link from our main README.