### PR TITLE
Add Jib devs as ONWERS for Jib catalogs

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -27,8 +27,10 @@ orgs:
     - AlanGreene
     - ameyer-pivotal
     - bigkevmcd
+    - briandealwis
     - carlos-logro
     - CarolynMabbott
+    - chanseokoh
     - chmouel
     - danielhelfand
     - dibbles
@@ -49,6 +51,7 @@ orgs:
     - khrm
     - kimsterv
     - kimholmes
+    - loosebazooka
     - Megan-Wright
     - mnuttall
     - nader-ziada


### PR DESCRIPTION
`ONWERS` files already merged. See https://github.com/tektoncd/catalog/pull/203#issuecomment-593258542

@loosebazooka