### PR TITLE
Add dashboard working group details

### DIFF
--- a/working-groups.md
+++ b/working-groups.md
@@ -34,6 +34,7 @@ The current working groups are:
 - [Documentation](#documentation)
 - [Productivity](#productivity)
 - [Beta release](#beta-release)
+- [Dashboard](#dashboard)
 
 ## General
 
@@ -192,3 +193,25 @@ is a temporary working group.
 
 
 
+## Dashboard
+
+This is the [`tektoncd/dashboard`](https://github.com/tektoncd/dashboard) working group.
+
+| Artifact                   | Link                                                                                                                                                                                                                                      |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------                                                                             |
+| Forum                      | [tekton-dev@](https://groups.google.com/forum/#!forum/tekton-dev)                                                                                                                                                                         |
+| Community Meeting VC       | [https://meet.google.com/zxa-zefw-zum](https://meet.google.com/zxa-zefw-zum)                                                                                                                                                              |
+| Community Meeting Calendar | Mondays every week, 4:00pm-4:30pm CET <br>[Calendar](https://calendar.google.com/event?action=TEMPLATE&tmeid=b3NxODE2YjlrY3NzMnYwMmpmamY5NnVobHFfMjAyMDAzMTZUMTUwMDAwWiBnb29nbGUuY29tX2Qzb3Zjdm8xcDMyMTloOTg5NTczdjk4Zm5zQGc&tmsrc=google.com_d3ovcvo1p3219h989573v98fns%40group.calendar.google.com&scp=ALL) |
+| Meeting Notes              | [Notes](https://docs.google.com/document/d/1bG4mbjycmFtIBezA6AJoQvaB4-v3874dhX7n-DhGAx0/edit)                                                                                                                                             |
+| Document Folder            | [Folder](https://drive.google.com/drive/folders/1SCS7q9Ns9m8p7MG_4URiFKirz1SgID_B)                                                                                                                                                        |
+| Slack Channel              | [#dashboard](https://tektoncd.slack.com/messages/dashboard)                                                                                                                                                                                 |
+
+
+| &nbsp;                                                        | Facilitators    | Company | Profile                                            |
+| -----------------------------------------------------------   | ----------      | ------- | ------------------------------------------------   |
+| <img width="30px" src="https://github.com/a-roberts.png">     | Adam Roberts    | IBM     | [a-roberts](https://github.com/a-roberts)          |
+| <img width="30px" src="https://github.com/mnuttall.png">      | Mark Nuttall    | IBM     | [mnuttall](https://github.com/mnuttall)            |
+| <img width="30px" src="https://github.com/skaegi.png">        | Simon Kaegi     | IBM     | [skaegi](https://github.com/skaegi)                |
+| <img width="30px" src="https://github.com/dibbles.png">       | Duane Appleby   | IBM     | [dibbles](https://github.com/dibbles)              |
+| <img width="30px" src="https://github.com/steveodonovan.png"> | Steve O'Donovan | IBM     | [steveodonovan](https://github.com/steveodonovan)  |
+| <img width="30px" src="https://github.com/AlanGreene.png">    | Alan Greene     | IBM     | [AlanGreene](https://github.com/AlanGreene)        |


### PR DESCRIPTION
Add details of dashboard working group meeting following existing
pattern, including links to Slack channel, meeting invite, recordings,
etc.

@bobcatfish @a-roberts fyi