### PR TITLE
Add requirements for joining the Tekton org 👪

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ Find out about our processes:
 * [Project OWNERS](process.md#OWNERS)
 * [Pull request reviews](process.md#reviews)
 * [Propose projects](process.md#proposing-projects)
-* [Github Org Management](org/README.md)
+* [Github Org Management](org/README.md), including [requirements to join the org](org/README.md#requirements)
 
 _For guidelines on how to contribute to `tektoncd/community` see [CONTRIBUTING.md](CONTRIBUTING.md)._

--- a/org/README.md
+++ b/org/README.md
@@ -7,3 +7,22 @@ This system uses [peribolos](https://github.com/kubernetes/test-infra/tree/maste
 to manage the org configuration.
 
 After config updates are made, an administrator must manually sync the configurations for them to take effect.
+
+## Requirements
+
+Feel free to open issues, comment, open pull requests or propose designs whether you
+are a member of the tektoncd org or not!
+
+If you are regularly contributing to repos in tektoncd, then you can become a
+member of the Tekton GitHub organization in order to have tests run against your
+pull requests without requiring [`ok-to-test`](process.md#prow-commands) and to be
+able to [`lgtm`](process.md#prow-commands) pull requests.
+
+To be eligible to become a member of the org you must (not that this is at the
+discretion of [the governing board members](governance.md)) do both of:
+
+* Opened 5 pull requests against projects in tektoncd
+* Reviewed 5 pull requests against projects in tektoncd
+
+OR you can be endorsed by existing contributors (e.g. if you are joining a team that
+is working on Tekton).


### PR DESCRIPTION
Previously we had no requirements beyond asking to join, but recently
the new governing board (https://github.com/tektoncd/community/pull/90)
discussed and tried to identify:

* What happens if you join (you can lgtm + you get ok-to-test)
* Why you would want this (probably only if you are regularly
  contributing)

The lgtm is something we want to be careful
around since this could result in arbititrary code in our released
binaries.

Even with ok-to-test we want to exercise caution because this means
running arbitrary code on our infrastructure with test priviledges.

The requirements in this commit are meant to attempt to demonstrate that
this person has been shown to be a contributor who needs and can
responsibly use these abilities.