### PR TITLE
Add tektoncd/hub owners to the org 🤺

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -31,6 +31,7 @@ orgs:
     - carlos-logro
     - CarolynMabbott
     - chanseokoh
+    - chetan-rns
     - chmouel
     - danielhelfand
     - dibbles
@@ -65,15 +66,19 @@ orgs:
     - popcor255
     - pradeepitm12
     - praveen4g0
+    - pratap0007
     - pritidesai
+    - PuneetPunamiya
     - raffamendes
+    - savitaashture
     - sbwsg
     - sclevine
+    - sergetron
     - shashwathi
     - simonjjones
     - skaegi
     - skim1420
-    - sergetron
+    - sm43
     - steveodonovan
     - sthaha
     - vincent-pli
@@ -81,4 +86,3 @@ orgs:
     - waveywaves
     - withlin
     - wlynch
-    - savitaashture


### PR DESCRIPTION
Adding chetan-rns, pratap007, PuneetPunamiya and sm43 as they are part of
the tekton/hub OWNERS, so they need to be part of the org (and they
are in the Red Hat team working on Tekton 😉).

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>