### PR TITLE
Add jerop to the org

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -46,6 +46,7 @@ orgs:
     - hrishin
     - iancoffey
     - imjasonh
+    - jerop
     - jessm12
     - jkutner
     - joseblas


### PR DESCRIPTION
(written by @bobcatfish ): @jerop has joined the Tekton team at Google and will be regularly contributing to Tekton Pipelines and later probably other Tekton project as well! 🎉 