### PR TITLE
Add info about EasyCLA 👩‍⚖️

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,6 @@ Find out about our processes:
 * [Pull request reviews](process.md#reviews)
 * [Propose projects](process.md#proposing-projects)
 * [Github Org Management](org/README.md), including [requirements to join the org](org/README.md#requirements)
+* [The CDF CLA](process.md#cla)
 
 _For guidelines on how to contribute to `tektoncd/community` see [CONTRIBUTING.md](CONTRIBUTING.md)._

--- a/process.md
+++ b/process.md
@@ -9,6 +9,7 @@ which you can find documented in their individual `CONTRIBUTING.md` files.
 * [Project OWNERS](#OWNERS)
 * Pull request [reviews](#reviews) and [process](#pull-request-process)
 * [Propose projects](process.md#proposing-projects)
+* [The CDF CLA](#cla)
 
 ## Finding something to work on
 
@@ -261,3 +262,17 @@ best-practices to make sure everyone interested can attend:
 * Try to record the meeting, and post a link to the recording.
 * If the meeting will be recurring, or have a large enough audience, use a poll to allow participants to vote on
   potential times.
+
+## CLA
+
+To contribute to repos in tektoncd you need to be authorized to contributed under the CDF Contributor's License
+Agreement (CLA) which is managed by EasyCLA via https://project.lfcla.com/.
+
+Contributors are authorized and managed via the CommunityBridge EasyCLA GitHub app. The first time you
+contribute to a repo that is covered by this CLA, the bot will post a comment prompting you to login to EasyCLA
+and either sign an individual CLA or indicate your affilation with a company that has signed it (each company
+is in charge of managing how they verify that you are actually part of the company, for example often this is
+managed via the domain your email address).
+
+Members of [the governing board](governance.md) are authorized to administer the CDF CLA via the website and
+can control which repos it is applied to.


### PR DESCRIPTION
We are switching Tekton over from using the Google CLA to using the CDF
CLA. This commit adds some docs about how it works. It is a bit
aspirational since at the moment I think I might be the only governing
board member who has access to admin the CLA however I have put in a
request to get everyone access.

I also thought CONTRIBUTING.md might be a better place for this info
however the CONTRIBUTING.md in this repo is only for this repo so I then
thought process.md might be a better place for org wide info. I also
wasn't sure if plumbing was a better place but this seems in between
since external contributors might want this info also.

As of right now I've turned this on for plumbing, community and friends.
Next steps:

1. Check with @vdemeester and @afrittoli and see if they run into any trouble
2. Make the check required
3. Warn everyone again that we're about to make the change
4. Turn on for the rest of the repos
5. Turn off the Google CLA (somehow)