### PR TITLE
Update docs on review process to reflect current behaviour

### DIFF
--- a/process.md
+++ b/process.md
@@ -150,8 +150,6 @@ Before a PR can be merged, it must have both `/lgtm` AND `/approve`:
   added to the repo itself
 * `/approve` can be added only by [OWNERS](#owners)
 
-[OWNERS](#owners) automatically get `/approve` but still will need an `/lgtm` to merge.
-
 The merge will happen automatically once the PR has both `/lgtm` and `/approve`,
 and all tests pass. If you don't want this to happen you should
 [`/hold`](#preventing-the-merge) the PR.


### PR DESCRIPTION
Previously users listed in the OWNERS files as approvers automatically
got a `/approve` on their PRs. With https://github.com/tektoncd/plumbing/pull/72
this is no longer the case. Update the docs to reflect this.