### PR TITLE
Add the Jason and Andrea as OWNERS to community

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,3 +6,5 @@ approvers:
 - vdemeester
 - kimsterv
 - abayer
+- ImJasonH
+- afrittoli


### PR DESCRIPTION
Given the new TEP process, the members of the Tekton governance
board should be owners of on the community repo, adding Jason
and Andrea who are both missing.