### PR TITLE
Add Florian to the org, to own the `helm` task.

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -41,6 +41,7 @@ orgs:
     - eddycharly
     - ekcasey
     - EliZucker
+    - fhopfensperger
     - gabemontero
     - garethr
     - hone


### PR DESCRIPTION
Florian would like to add a new `helm` task to the Tekton Catalog. He would like to maintain and own this task.
https://github.com/tektoncd/catalog/pull/334

Florian works in his daily job as a solution architect for IBM Germany, where he likes to rely on open source technologies. If he finds a bug in one of his used software, he does not hesitate to fix it or add new features. He has already spoken with the `helm` maintainers and is looking for active support to maintain this new Tekton Task.

Florian is excited about the cool features around Tekton and is looking forward to using them more and more in customer projects.

Signed-off-by: Florian Hopfensperger <florian.hopfensperger@de.ibm.com>