### PR TITLE
Add contributor and reviewer expectations

### DIFF
--- a/standards.md
+++ b/standards.md
@@ -1,47 +1,126 @@
-# Tekton Development Standards
+# Tekton Pipelines Contributor and Reviewer Expectations
 
-This doc contains the standards we try to uphold across all project
-in the Tekton org.
+The purpose of this doc is to:
 
-## Principles
+* Outline for contributors what we expect to see in a pull request
+* Establish a baseline for reviewers so they know at a minimum what to look for
 
-When possbile, try to practice:
+Each Pull Request is expected to meet the following expectations around:
 
-- **Documentation driven development** - Before implementing anything, write
-  docs to explain how it will work
-- **Test driven development** - Before implementing anything, write tests to
-  cover it
+* [Pull Request Description](#pull-request-description)
+* [Commits](#commits)
+* [Docs](#docs)
+* [Tests](#tests)
+* [API Design](#api-design)
+* [Functionality](#functionality)
+* [Content](#content)
+* [Code](#code)
 
-Minimize the number of integration tests written and maximize the unit tests!
-Unit test coverage should increase or stay the same with every PR.
+_See also [the Tekton review process](https://github.com/tektoncd/community/blob/master/process.md#reviews)._
 
-This means that most PRs should include both:
+## Pull request description
 
-1. Tests
-2. Documentation updates
+* Include a link to the issue being addressed, but describe the context for the reviewer
+  * If there is no issue, consider whether there should be one:
+    * New functionality must be designed and approved, may require a TEP
+    * Bugs should be reported in detail
+  * Release notes filled in for user visible changes (bugs + features),
+    or removed if not applicable (refactoring, updating tests)
+  * If the template contains a checklist, it should be checked off
 
-## Commit Messages
+## Commits
 
-All commit messages should follow
-[these best practices](https://chris.beams.io/posts/git-commit/), specifically:
+* Follow [commit messages best practices](https://chris.beams.io/posts/git-commit/):
+  1. Separate subject from body with a blank line
+  2. Limit the subject line to 50 characters
+  3. Capitalize the subject line
+  4. Do not end the subject line with a period
+  5. Use the imperative mood in the subject line
+  6. Wrap the body at 72 characters
+  7. Use the body to explain what and why vs. how. Don't just link to an issue and
+      [aim for 2 paragraphs](https://www.youtube.com/watch?v=PJjmw9TRB7s), e.g.:
+      * What is the problem being solved?
+      * Why is this the best approach?
+      * What other approaches did you consider?
+      * What side effects will this approach have?
+      * What future work remains to be done?
+* Prefer one commit per PR; if there are multiple commits, ensure each is
+  self-contained and makes sense without the context of the others in the PR
 
-- Start with a subject line
-- Contain a body that explains _why_ you're making the change you're making
-- Reference an issue number one exists, closing it if applicable (with text such
-  as
-  ["Fixes #245" or "Closes #111"](https://help.github.com/articles/closing-issues-using-keywords/))
+## Docs
 
-Aim for [2 paragraphs in the body](https://www.youtube.com/watch?v=PJjmw9TRB7s).
-Not sure what to put? Include:
+* Include Markdown doc updates for user visible features
+* Spelling and grammar should be correct
+* Try to make formatting look as good as possible (use preview mode to check)
+* Follow [content](https://github.com/tektoncd/website/blob/master/content/en/doc-con-content.md)
+  and [formatting](https://github.com/tektoncd/website/blob/master/content/en/doc-con-formatting.md) guidelines
+* Should explain thoroughly how the new feature works
 
-- What is the problem being solved?
-- Why is this the best approach?
-- What other approaches did you consider?
-- What side effects will this approach have?
-- What future work remains to be done?
+## Tests
 
-## Coding standards
+* New features (and often/whenever possible bug fixes) have one or both of:
+  * Examples (i.e. yaml tests)
+  * End to end tests
+  * Reconciler tests
+* New types have:
+  * Validation + validation tests
+* Unit tests:
+  * Coverage should remain the same or increase
+  * Test exported functions only, in isolation:
+    * Each exported function should have tests
+    * Each test should only test one function at a time
+    * If you find yourself wanting to test an unexported function, consider whether
+      it would make sense to move the test into another package and export it
+* Test code
+  * When using cmp.Diff the argument order is always (want, got) and in the error message include (-want +got)
+    (and/or use a lib like [PrintWantGot](https://github.com/tektoncd/pipeline/blob/master/test/diff/print.go))
+  * Table driven tests: do not use the same test for success and fail cases if the logic is different
+    (e.g. do not have two sets of test logic, gated with `wantErr`)
 
-### Go
+## API Design
 
-- [Go code review comments](https://github.com/golang/go/wiki/CodeReviewComments)
+* Avoid kubernetes specific feature in our APIs as much as possible
+* If we don’t definitely need the feature, don’t add it
+  * Must be backed up with [CI/CD specific use cases](https://github.com/tektoncd/community/blob/master/roadmap.md#mission-and-vision)
+* Prefer keeping the API simple:
+  * If you can avoid adding a new feature, don’t add it
+  * Prefer reusing existing features to adding new ones
+
+## Functionality
+
+* It should be safe to cut a release at any time, i.e. merging this PR should not
+  put us into an unreleasable state
+    * When incrementally adding new features, this may mean that a release could contain
+      a partial feature, i.e. the type specification only but no functionality
+
+## Content
+
+* Whenever logic is added that uses an image that wasn’t used before, the image used should
+  be configurable on the command line so that distributors can build images that meet their
+  support and licensing requirements
+* Refactoring should be merged separately from bug fixes and features
+  * i.e. if you refactor as part of implementing something, commit it and merge it before merging the change
+* Prefer small pull requests; if you can think of a way to break up the pull request into multiple, do it
+
+## Code
+* Reviewers are expected to understand the changes well enough that they would feel confident
+  saying the understand what is changing and why:
+  * Read through all the code changes
+  * Read through linked issues and pull requests, including the discussions
+* Reconciler changes:
+  * Avoid adding functions to the reconciler struct
+  * Avoid adding functions to the reconciler package
+  * Return an error if you want the change to be re-queued, otherwise do not
+    (better yet, use [permanent errors](https://github.com/tektoncd/pipeline/issues/2474))
+* Prefer small well factored packages with unit tests
+* Pass kubernetes and tekton client functions into functions that need them as params so
+  they can be easily mocked in unit tests
+* [Go Code Review comments](https://github.com/golang/go/wiki/CodeReviewComments)
+  * All public functions and attributes have docstrings
+  * Don’t panic
+  * Error strings are not capitalized
+  * Handle all errors ([gracefully](https://dave.cheney.net/2016/04/27/dont-just-check-errors-handle-them-gracefully))
+    * When returning errors, add more context with `fmt.Errorf` and `%v`
+  * Use meaningful package names (avoid util, helper, lib)
+  * Prefer short variable names
+


### PR DESCRIPTION
These started out as just being for Tekton Pipelines, discussed in the productivity
working group, but @dibyom pointed out they make sense for triggers too,
so let's see if we want to adopt these for all the tektoncd projects or if we just want to
constrain it to triggers + pipelines.

The goal of these guidelines is to make sure that contributors
understand what is expected in their submissions and also so that a
reviewer (especially if someone wants to join and start reviewing who
hasn't reviewed as part of this project before) will know when they
approve + lgtm what they are expected to have checked.

Would like to hear feedback from OWNERS (approvers and reviewers) across all Tektoncd projects, both:
1. Any tweaks or additions or things you strongly disagree with
2. Whether you'd rather have your own for your project vs. having these expectations org wide

* pipelines: @bobcatfish @dlorenc @ImJasonH @vdemeester @afrittoli @dibyom @sbwsg
* cli: @vdemeester @sthaha @hrishin @chmouel @danielhelfand @piyush-garg @pradeepitm12
* dashboard: @a-roberts @alangreene @mnuttall @skaegi @steveodonovan @dibbles @akihikokuroda @carolynmabbott @megan-wright @ncskier @eddycharly
* website: @bobcatfish @dlorenc @vdemeester @kimsterv @abayer @lucperkins @afrittoli @skaegi @AlanGreene
* triggers: @bobcatfish @dibyom @dlorenc @iancoffey @ncskier @vtereso @wlynch
* hub: @vdemeester @sthaha @PuneetPunamiya @chetan-rns @pratap0007 @sm43
* chains: @dlorenc @font @lukehinds @mpeters @dibyom @sbwsg
* operator: @vdemeester @sthaha @nikhil-thomas @houshengbo @vincent-pli


(I skipped some repos where the OWNERS are already covered via other lists)