### PR TITLE
Add vinamra28 as an org member

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -94,6 +94,7 @@ orgs:
     - sm43
     - steveodonovan
     - sthaha
+    - vinamra28
     - vincent-pli
     - vtereso
     - waveywaves


### PR DESCRIPTION
Hi, Vinamra is actively contributing to `tektoncd/catalog` and has also started contributing to `tektoncd/cli` and `tektoncd/pipeline`. Vinamra is an intern at Red Hat. Vinamra is excited about the cool features around Tekton and is looking forward to contribute more in projects.

Signed-off-by: vinamra28 <vinjain@redhat.com>