### PR TITLE
Add divyansh42 to Tekton org

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -36,6 +36,7 @@ orgs:
     - danielhelfand
     - dibbles
     - dibyom
+    - divyansh42
     - dorismeixing
     - dwnusbaum
     - eddycharly


### PR DESCRIPTION
Hi, Divyanshu is actively contributing to `tektoncd/catalog` and added few tasks to catalog and has also started contributing to `tektoncd/cli` and `tektoncd/pipeline`. Divyanshu is an intern at Red Hat. Divyanshu is looking forward to contribute more in projects and add more features.

Signed-off-by: Divyansh42 <diagrawa@redhat.com>