### PR TITLE
org: maintain tektoncd teams using peribolos

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -116,6 +116,7 @@ orgs:
         - kimsterv
         - dlorenc
         - sbwsg
+        - chmouel
         privacy: closed
         repos:
           catalog: write
@@ -123,10 +124,10 @@ orgs:
         description: "the chains maintainers"
         maintainers:
         - vdemeester
+        - dlorenc
         members:
         - mpeters
         - skelterjohn
-        - dlorenc
         - font
         - lukehinds
         privacy: closed
@@ -143,6 +144,7 @@ orgs:
         - piyush-garg
         - hrishin
         - danielhelfand
+        - pradeepitm12
         privacy: closed
         repos:
           cli: write
@@ -171,7 +173,10 @@ orgs:
         - AlanGreene
         - mnuttall
         - a-roberts
-        - kimholmes
+        - dibbles
+        - eddycharly
+        - steveodonovan
+        - carolynmabbott
         privacy: closed
         repos:
           dashboard: write
@@ -206,7 +211,6 @@ orgs:
         - vdemeester
         members:
         - sthaha
-        - chetan-rns
         - pratap0007
         - PuneetPunamiya
         - SM43
@@ -236,6 +240,7 @@ orgs:
         - kimsterv
         - dlorenc
         - dibyom
+        - sbwsg
         privacy: closed
         repos:
           plumbing: write

--- a/org/org.yaml
+++ b/org/org.yaml
@@ -105,3 +105,151 @@ orgs:
     - withlin
     - wlynch
     - yuege01
+    teams:
+      catalog.maintainers:
+        description: "the catalog maintainers"
+        maintainers:
+        - vdemeester
+        - ImJasonH
+        - bobcatfish
+        members:
+        - kimsterv
+        - dlorenc
+        - sbwsg
+        privacy: closed
+        repos:
+          catalog: write
+      chains.maintainers:
+        description: "the chains maintainers"
+        maintainers:
+        - vdemeester
+        members:
+        - mpeters
+        - skelterjohn
+        - dlorenc
+        - font
+        - lukehinds
+        privacy: closed
+        repos:
+          chains: write
+      cli.maintainers:
+        description: "the cli maintainers"
+        maintainers:
+        - vdemeester
+        - bobcatfish
+        members:
+        - chmouel
+        - sthaha
+        - piyush-garg
+        - hrishin
+        - danielhelfand
+        privacy: closed
+        repos:
+          cli: write
+          homebrew-tools: write
+      core.maintainers:
+        description: "the core maintainers team (pipeline)"
+        maintainers:
+        - vdemeester
+        - ImJasonH
+        - bobcatfish
+        - afrittoli
+        members:
+        - pritidesai
+        - dlorenc
+        - dibyom
+        - sbwsg
+        privacy: closed
+        repos:
+          pipeline: write
+      dashboard.maintainers:
+        description: "the dashboard mainatiners"
+        maintainers:
+        - bobcatfish
+        - skaegi
+        members:
+        - AlanGreene
+        - mnuttall
+        - a-roberts
+        - kimholmes
+        privacy: closed
+        repos:
+          dashboard: write
+      experimental.maintainers:
+        description: "the experimental maintainers"
+          github repo
+        maintainers:
+        - abayer
+        - bobcatfish
+        - mnuttall
+        members:
+        - skaegi
+        - dlorenc
+        - a-roberts
+        - dibbles
+        privacy: closed
+        repos:
+          experimental: write
+      homebrew.maintainers:
+        description: "the homebrew-tools maintainers"
+        maintainers:
+        - vdemeester
+        members:
+        - chmouel
+        - danielhelfand
+        privacy: closed
+        repos:
+          homebrew-tools: write
+      hub.maintainers:
+        description: "the hub maintainers"
+        maintainers:
+        - vdemeester
+        members:
+        - sthaha
+        - chetan-rns
+        - pratap0007
+        - PuneetPunamiya
+        - SM43
+        privacy: closed
+        repos:
+          hub: write
+      operator.maintainers:
+        description: "the operator maintainers"
+        maintainers:
+        - vdemeester
+        members:
+        - houshengbo
+        - sthaha
+        - nikhil-thomas
+        - vincent-pli
+        privacy: closed
+        repos:
+          operator: write
+      plumbing.maintainers:
+        description: "the plumbing maintainers"
+        maintainers:
+        - vdemeester
+        - abayer
+        - bobcatfish
+        - afrittoli
+        members:
+        - kimsterv
+        - dlorenc
+        - dibyom
+        privacy: closed
+        repos:
+          plumbing: write
+      triggers.maintainers:
+        description: "the triggers maintainers"
+        maintainers:
+        - bobcatfish
+        members:
+        - iancoffey
+        - dlorenc
+        - wlynch
+        - dibyom
+        - ncskier
+        - vtereso
+        privacy: closed
+        repos:
+          triggers: write


### PR DESCRIPTION
This map the current teams from tektoncd so that the membership can be automated 😉. Overall the membership for this team should reflect the main `OWNERS` file approvers (and `OWNER_ALIASES` if used). I'll work on automating this in follow-ups :wink: 

Will need the following flags in [`peribolos.yaml`](https://github.com/tektoncd/plumbing/blob/master/tekton/resources/org-permissions/peribolos.yaml#L22)

```
  -fix-team-members
    	Add/remove team members if set
  -fix-team-repos
    	Add/remove team permissions on repos if set
  -fix-teams
    	Create/delete/update teams if set
```


Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @afrittoli @dlorenc @bobcatfish @ImJasonH @abayer 