### PR TITLE
Add Max to the org

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -104,6 +104,7 @@ orgs:
     - waveywaves
     - withlin
     - wlynch
+    - wumaxd
     - yuege01
     teams:
       catalog.maintainers:


### PR DESCRIPTION
Max became recently a contributor to the Tekton project. He created some python tasks for the catalog and proposed some other ideas for improvement (tektoncd/catalog#413, tektoncd/catalog#459). He would like to maintain and own the created and derived tasks to support the project. Also the the test for several tasks are based on a repository of him.

_Introduced and improvements tasks_
tektoncd/catalog#432
tektoncd/catalog#470

_Derived tasks_
tektoncd/catalog#458

Max is working at IBM and uses various open source solutions in his daily job. This includes Tekton and he is excited how this project will develop in the future.

Signed-off-by: wumaxd <wurzer.maxi@gmx.de>