### PR TITLE
Move catalog organization TEP to implementable

### DIFF
--- a/teps/0003-tekton-catalog-organization.md
+++ b/teps/0003-tekton-catalog-organization.md
@@ -5,8 +5,8 @@ authors:
   - "@sthaha"
   - "@bobcatfish"
 creation-date: 2020-06-11
-last-updated: 2020-07-07
-status: proposed
+last-updated: 2020-08-12
+status: implementable
 ---
 
 # TEP-0002: Tekton Catalog Organization


### PR DESCRIPTION
We've already started work on this in the catalog so we could even go
straight to "implemented" if we wanted to, but since we haven't
implemented all of it (e.g. testing for verifiable and official tiers
via #170) maybe "implementable" makes the most sense for now?

@vdemeester @sthaha 