### PR TITLE
org: khrm maintainer of triggers

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -251,6 +251,7 @@ orgs:
         members:
         - iancoffey
         - dlorenc
+        - khrm
         - wlynch
         - dibyom
         - ncskier


### PR DESCRIPTION
Related to https://github.com/tektoncd/triggers/commit/f39feca70117455dbd765cdb9a3c8fbcad134977

/cc @khrm @dibyom @afrittoli @bobcatfish @ImJasonH 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>