### PR TITLE
Add Ziheng to the org

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -107,6 +107,7 @@ orgs:
     - wumaxd
     - ywluogg
     - yuege01
+    - ziheng
     teams:
       catalog.maintainers:
         description: "the catalog maintainers"


### PR DESCRIPTION
Ziheng became recently a contributor to the Tekton Dashboard project. He would like to maintain and own the created and derived tasks to support the project. Also the the test for several tasks are based on a repository of him.

Introduced and improvements tasks
https://github.com/tektoncd/dashboard/pull/643

Ziheng is working at IBM and uses various open source solutions in his daily job. This includes Tekton and he is excited how this project will develop in the future.