### PR TITLE
Move optional workspaces TEP to implementable

### DIFF
--- a/teps/0010-optional-workspaces.md
+++ b/teps/0010-optional-workspaces.md
@@ -4,7 +4,7 @@ authors:
   - "@sbwsg"
 creation-date: 2020-08-03
 last-updated: 2020-08-12
-status: proposed
+status: implementable
 ---
 
 # TEP-0010: Optional Workspaces


### PR DESCRIPTION
The optional workspaces TEP was pretty thoroughly edited and reviewed
during the proposal phase (https://github.com/tektoncd/community/pull/169).
There were no outstanding blockers or requests for more information that
I'm aware of that should prevent this TEP moving to implementable.

This PR moves the optional workspaces TEP into implementable state with
intention to go ahead and add this feature to Tekton Pipelines.