### PR TITLE
TEP-0017 Propose creating shell-escaped parameters

### DIFF
--- a/teps/0017-shell-escaped-params.md
+++ b/teps/0017-shell-escaped-params.md
@@ -1,5 +1,5 @@
 ---
-title: Provide shell-escaped parameters
+title: Provide Shell-Escaped Parameters
 authors:
   - "@coryrc"
 creation-date: 2020-09-15
@@ -7,7 +7,7 @@ last-updated: 2020-09-15
 status: in pr review
 ---
 
-# Tekton Enhancement Proposal Process
+# TEP-0017 Provide Shell-Escaped Parameters
 
 ## Table of Contents
 
@@ -26,7 +26,7 @@ status: in pr review
 - [Test Plan](#test-plan)
 - [Drawbacks](#drawbacks)
 - [Alternatives](#alternatives)
-- [References](#references-optional)
+- [References](#references)
 <!-- /toc -->
 
 ## Summary

--- a/teps/0017-shell-escaped-params.md
+++ b/teps/0017-shell-escaped-params.md
@@ -146,6 +146,30 @@ environment variable approach.
 Environment variables and files have the downside of possible hidden
 dependencies in the image executables.
 
+4. Alternative 1 could be made more concise by providing the expansion
+`$(params.in.env)`; when used, the parameter's value is placed in an arbitrary
+environment variable whose name is provided by that expansion. i.e.
+
+```yaml
+steps:
+   script: |
+        printf '%s' "${$(params.script.env)}" > input-script.sh
+```
+
+This name wouldn't be limited to scripts either and could be supplied as an
+arg to any command, though the use case for that is very limited.
+
+5. Keep being unsafe. For example, is param `in` is `'; rm -fR /;` and used:
+
+```yaml
+steps:
+   script: |
+        printf '%q' '$(params.in)'
+```
+
+it'll expand to `printf '%q' ''; rm -fR /;` deleting from the root, though you
+can imagine worse things it could do.
+
 ## References
 
 [Provide shell-escaped parameters for `script:`](https://github.com/tektoncd/pipeline/issues/3226)

--- a/teps/0017-shell-escaped-params.md
+++ b/teps/0017-shell-escaped-params.md
@@ -4,7 +4,7 @@ authors:
   - "@coryrc"
 creation-date: 2020-09-15
 last-updated: 2020-09-15
-status: in pr review
+status: proposed
 ---
 
 # TEP-0017 Provide Shell-Escaped Parameters
@@ -42,7 +42,7 @@ offering a shell-escaped version of every parameter.
 
 ### Goals
 
-Provide a way to place parameters directly into a `script:` without it being
+Provide a way to place parameters directly into the default `script:` without being
 interpreted by the shell.
 
 ### Non-Goals
@@ -59,13 +59,18 @@ In a Task or Pipeline, for each parameter `foo`, provide `$(params.foo.shell-esc
 
 This variable shall be escaped according to `printf '%q'` rules as used in bash.
 
+Support Bourne, Bourne-Again, Busybox, and Debian Almquist shells against
+injection, but don't purposefully prevent its usage in other scenarios.
+
 ### User Stories
 
 #### Story 1
 
 My Task allows users to specify a destination filename. The user could pass
 valid file names containing any of ` <>|\!*?;&"'` (or more) which would be
-impossible to robustly address all possibilities when used directly in the script.
+impossible to robustly address all possibilities when used directly in the
+script. For example, single-quoting parameters could not protect against
+`'; rm -fR *;'`.
 
 #### Story 2
 
@@ -79,8 +84,7 @@ printf '%s' "$(params.foo)" > included-script.sh
 
 ### Risks and Mitigations
 
-People could believe it means they can take unsanitized data from untrusted
-sources when we aren't supplying that guarantee.
+We may not have the resources to exhaustively test and security-harden this feature.
 
 ## Design Details
 
@@ -127,6 +131,11 @@ steps:
     - /tekton/workspace/some-file
     - $(params.script)
 ```
+
+The parameters could also be provided in the same way results are supplied:
+`/tekton/parameters/in` could be a file with the exact contents. I believe, in
+bash at least, `command "$(cat /tekton/parameters/in)"` is as safe as the
+environment variable approach.
 
 ## References
 

--- a/teps/0017-shell-escaped-params.md
+++ b/teps/0017-shell-escaped-params.md
@@ -92,7 +92,7 @@ We may not have the resources to exhaustively test and security-harden this feat
 
 ## Design Details
 
-Arrays will be treated as flattened strings.
+If the parameter type is an array, it will fail validation.
 
 ## Test Plan
 


### PR DESCRIPTION
Related: tektoncd/pipeline#3226

It is difficult to safely use parameters in a `script:` scalar. This
TEP proposes offering a shell-escaped version of every parameter.