### PR TITLE
Update hermekton TEP number to 0025

### DIFF
--- a/teps/0025-hermekton.md
+++ b/teps/0025-hermekton.md
@@ -1,5 +1,5 @@
 ---
-title: TEP-NNNN-Hermetic-Builds
+title: TEP-0025-Hermetic-Builds
 authors:
   - "@dlorenc"
 creation-date: 2020-09-11
@@ -7,7 +7,7 @@ last-updated: 2020-09-11
 status: proposed
 ---
 
-# TEP-NNNN: Hermekton: Hermetic Builds in Tekton Pipelines
+# TEP-0025: Hermekton: Hermetic Builds in Tekton Pipelines
 
 <!-- toc -->
 - [Summary](#summary)


### PR DESCRIPTION
There were two TEPs with the number 0024 - this one and embedded trigger
templates. Since that one already has a commit merged, I'm changing this to use
0025 instead.

/cc @dlorenc @bobcatfish
