### PR TITLE
Move optional workspaces to 'implemented' state

### DIFF
--- a/teps/0010-optional-workspaces.md
+++ b/teps/0010-optional-workspaces.md
@@ -3,8 +3,8 @@ title: TEP-0010-Optional-Workspaces
 authors:
   - "@sbwsg"
 creation-date: 2020-08-03
-last-updated: 2020-08-12
-status: implementable
+last-updated: 2020-10-15
+status: implemented
 ---
 
 # TEP-0010: Optional Workspaces


### PR DESCRIPTION
Optional workspaces is now available since pipelines 0.17.

This commit moves workspaces tep document to implemented status.