### PR TITLE
Add design principles to the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ See our standards regarding:
 
 * [Code of conduct](code-of-conduct.md)
 * [Development principles](standards.md#principles)
+* [Design principles](design-principles.md)
 * [Commit messages](standards.md#commit-messages)
 * [Go coding standards](standards.md#go)
 * [User profiles](user-profiles.md)


### PR DESCRIPTION
Adding a link to the [design principles](https://github.com/tektoncd/community/blob/master/design-principles.md) introduced in https://github.com/tektoncd/community/pull/171 to increase visibility to contributors

Fixes https://github.com/tektoncd/community/pull/171#issuecomment-721197989

/kind misc
/cc @bobcatfish 
