### PR TITLE
Create teams of collaborators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# IDEs
+.idea/
+.vscode/
+
+# Python
+hack/__pycache__/

--- a/org/README.md
+++ b/org/README.md
@@ -20,7 +20,7 @@ member of the Tekton GitHub organization in order to have tests run against your
 pull requests without requiring [`ok-to-test`](process.md#prow-commands) and to be
 able to [`lgtm`](process.md#prow-commands) pull requests.
 
-To be eligible to become a member of the org you must (not that this is at the
+To be eligible to become a member of the org you must (note that this is at the
 discretion of [the governing board members](governance.md)) do both of:
 
 * Opened 5 pull requests against projects in tektoncd

--- a/org/collaborator.py
+++ b/org/collaborator.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script helps synchronize contents from their respective sources of
+# truth (usually GitHub repositories of each Tekton
+# components, such as tektoncd/pipelines) to tektoncd/website.
+
+# This script builds a table collaborator for the various repos in the
+# Tekton CD org. The list of collaborators is used to create configuration
+# for collaborator teams on GitHub side, which are then sync'ed to GitHub
+# via the existing peribolos infrastructure.
+
+# Collaborators are selected by searching for anyone in the Tekton org
+# that has contributed at least 5 commits (ever) to the specific repo.
+# This script is meant as a one-off to setup the initial teams. Further
+# edits to the teams will be managed by PRs to the org/org.yaml config.
+
+import logging
+import os
+
+import github
+from ruamel.yaml import YAML
+
+
+ORG_CONFIG = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'org.yaml')
+
+def get_contributors_maintainers(github_token):
+    g = github.Github(github_token)
+
+    # Get the ORG members
+    tektoncd = g.get_organization("tektoncd")
+    members = [x for x in tektoncd.get_members()]
+    members_ids = [x.node_id for x in members]
+
+    # Get the list of repos
+    repos = [x for x in tektoncd.get_repos() if x.name != '.github']
+
+    # Get stats/contributors for each repo with 5+ commits
+    contributors = {}
+    maintainers = {}
+    for repo in repos:
+        logging.info(f'Searching contributors to {repo.name}')
+        # Get the list of contributors that have 5+ commits and are members
+        contributors[repo.name] = set([
+            x.author.login for x in repo.get_stats_contributors()
+            if x.total >= 5 and x.author.node_id in members_ids])
+
+        # Get the list of maintainers and merge them to a set
+        logging.info(f'Searching maintainers to {repo.name}')
+        _maintainers = [x for x in repo.get_teams()
+            if x.name.endswith('.maintainers')]
+        if len(_maintainers) > 0:
+            maintainers[repo.name] = set([x.login for x in _maintainers[0].get_members()])
+
+    # Any maintainer on any repo is allowed to lgtm on community (for TEPs)
+    for repo in repos:
+        contributors['community'] |= maintainers.get(repo.name, set())
+
+    return contributors, maintainers
+
+
+def update_collaborator_teams(contributors, maintainers):
+    yaml = YAML()
+
+    # Load the YAML config
+    logging.info(f'Loading org configuration from {ORG_CONFIG}')
+    with open(ORG_CONFIG, 'r') as org_config_file:
+        org_config = yaml.load(org_config_file)
+
+    # Update the config with collaborator teams
+    for repo, collaborators in contributors.items():
+        repo_name = repo if repo != 'pipeline' else 'core'
+        team_name = f'{repo_name}.collaborators'
+        team = dict(
+            description=f'The {repo_name} collaborators',
+            maintainers=list(maintainers.get(repo, ['bobcatfish'])),
+            members = list(collaborators) or ['bobcatfish'],
+            privacy = 'closed',
+            repos = {repo: 'read'}
+        )
+        logging.info(f'Adding team {team_name}')
+        org_config['orgs']['tektoncd']['teams'][team_name] = team
+
+    # Save the config back to disk
+    logging.info(f'Saving org configuration to {ORG_CONFIG}')
+    with open(ORG_CONFIG, 'w') as org_config_file:
+        yaml.dump(org_config, org_config_file)
+
+if __name__ == '__main__':
+    github_token = os.getenv('GITHUB_TOKEN')
+    if not github_token:
+        logging.error('GITHUB_TOKEN must be set')
+        sys.exit(1)
+    contributors, maintainers = get_contributors_maintainers(github_token)
+    update_collaborator_teams(contributors, maintainers)

--- a/org/org.yaml
+++ b/org/org.yaml
@@ -9,13 +9,13 @@ orgs:
     - imjasonh
     - afrittoli
     billing_email: info@cd.foundation
-    company: ""
+    company: ''
     default_repository_permission: read
-    description: ""
-    email: ""
+    description: ''
+    email: ''
     has_organization_projects: true
     has_repository_projects: true
-    location: ""
+    location: ''
     members:
     - 16yuki0702
     - AlanGreene
@@ -122,7 +122,7 @@ orgs:
     - ziheng
     teams:
       catalog.maintainers:
-        description: "the catalog maintainers"
+        description: the catalog maintainers
         maintainers:
         - vdemeester
         - ImJasonH
@@ -136,7 +136,7 @@ orgs:
         repos:
           catalog: write
       chains.maintainers:
-        description: "the chains maintainers"
+        description: the chains maintainers
         maintainers:
         - vdemeester
         - dlorenc
@@ -149,7 +149,7 @@ orgs:
         repos:
           chains: write
       cli.maintainers:
-        description: "the cli maintainers"
+        description: the cli maintainers
         maintainers:
         - vdemeester
         - bobcatfish
@@ -165,7 +165,7 @@ orgs:
           cli: write
           homebrew-tools: write
       core.maintainers:
-        description: "the core maintainers team (pipeline)"
+        description: the core maintainers team (pipeline)
         maintainers:
         - vdemeester
         - ImJasonH
@@ -180,7 +180,7 @@ orgs:
         repos:
           pipeline: write
       dashboard.maintainers:
-        description: "the dashboard mainatiners"
+        description: the dashboard maintainers
         maintainers:
         - bobcatfish
         - skaegi
@@ -196,7 +196,7 @@ orgs:
         repos:
           dashboard: write
       experimental.maintainers:
-        description: "the experimental maintainers"
+        description: the experimental maintainers
         maintainers:
         - abayer
         - bobcatfish
@@ -210,7 +210,7 @@ orgs:
         repos:
           experimental: write
       homebrew.maintainers:
-        description: "the homebrew-tools maintainers"
+        description: the homebrew-tools maintainers
         maintainers:
         - vdemeester
         members:
@@ -220,7 +220,7 @@ orgs:
         repos:
           homebrew-tools: write
       hub.maintainers:
-        description: "the hub maintainers"
+        description: the hub maintainers
         maintainers:
         - vdemeester
         members:
@@ -232,7 +232,7 @@ orgs:
         repos:
           hub: write
       operator.maintainers:
-        description: "the operator maintainers"
+        description: the operator maintainers
         maintainers:
         - vdemeester
         members:
@@ -244,7 +244,7 @@ orgs:
         repos:
           operator: write
       plumbing.maintainers:
-        description: "the plumbing maintainers"
+        description: the plumbing maintainers
         maintainers:
         - vdemeester
         - abayer
@@ -263,7 +263,7 @@ orgs:
         repos:
           plumbing: write
       triggers.maintainers:
-        description: "the triggers maintainers"
+        description: the triggers maintainers
         maintainers:
         - bobcatfish
         members:
@@ -277,3 +277,400 @@ orgs:
         privacy: closed
         repos:
           triggers: write
+      website.maintainers:
+        description: the website maintainers
+        maintainers:
+        - bobcatfish
+        members:
+        - bobcatfish
+        - dlorenc
+        - vdemeester
+        - kimsterv
+        - abayer
+        - lucperkins
+        - afrittoli
+        - skaegi
+        - AlanGreene
+        - jjasghar
+        - popcor255
+        privacy: closed
+        repos:
+          website: write
+      core.collaborators:
+        description: The core collaborators
+        maintainers:
+        - bobcatfish
+        - sbwsg
+        - dlorenc
+        - afrittoli
+        - vdemeester
+        - pritidesai
+        - dibyom
+        - ImJasonH
+        members:
+        - EliZucker
+        - barthy1
+        - bobcatfish
+        - houshengbo
+        - dibyom
+        - savitaashture
+        - dibbles
+        - danielhelfand
+        - chmouel
+        - dlorenc
+        - sthaha
+        - withlin
+        - GregDritschler
+        - Peaorl
+        - piyush-garg
+        - AlanGreene
+        - afrittoli
+        - sbwsg
+        - wlynch
+        - ImJasonH
+        - abayer
+        - jlpettersson
+        - dwnusbaum
+        - waveywaves
+        - mattmoor
+        - jerop
+        - sergetron
+        - othomann
+        - hrishin
+        - FogDong
+        - vincent-pli
+        - vdemeester
+        - psschwei
+        - skaegi
+        - shashwathi
+        - pritidesai
+        - nader-ziada
+        privacy: closed
+        repos:
+          pipeline: read
+      website.collaborators:
+        description: The website collaborators
+        maintainers:
+        - bobcatfish
+        members:
+        - bobcatfish
+        - sergetron
+        - popcor255
+        - skaegi
+        - afrittoli
+        - AlanGreene
+        - vdemeester
+        - jjasghar
+        privacy: closed
+        repos:
+          website: read
+      community.collaborators:
+        description: The community collaborators
+        maintainers:
+        - bobcatfish
+        members:
+        - bobcatfish
+        - SM43
+        - CarolynMabbott
+        - mnuttall
+        - houshengbo
+        - font
+        - dibyom
+        - eddycharly
+        - savitaashture
+        - dibbles
+        - danielhelfand
+        - chmouel
+        - pradeepitm12
+        - lukehinds
+        - dlorenc
+        - sthaha
+        - piyush-garg
+        - AlanGreene
+        - afrittoli
+        - sbwsg
+        - wlynch
+        - ImJasonH
+        - abayer
+        - khrm
+        - skelterjohn
+        - iancoffey
+        - jerop
+        - vtereso
+        - ncskier
+        - hrishin
+        - a-roberts
+        - steveodonovan
+        - PuneetPunamiya
+        - vdemeester
+        - kimsterv
+        - vincent-pli
+        - pratap0007
+        - mpeters
+        - skaegi
+        - nikhil-thomas
+        - pritidesai
+        privacy: closed
+        repos:
+          community: read
+      dashboard.collaborators:
+        description: The dashboard collaborators
+        maintainers:
+        - bobcatfish
+        - dibbles
+        - CarolynMabbott
+        - mnuttall
+        - skaegi
+        - a-roberts
+        - steveodonovan
+        - AlanGreene
+        - eddycharly
+        members:
+        - dibbles
+        - CarolynMabbott
+        - Megan-Wright
+        - mnuttall
+        - akihikokuroda
+        - skaegi
+        - ncskier
+        - a-roberts
+        - steveodonovan
+        - AlanGreene
+        - vdemeester
+        - jessm12
+        - carlos-logro
+        privacy: closed
+        repos:
+          dashboard: read
+      experimental.collaborators:
+        description: The experimental collaborators
+        maintainers:
+        - abayer
+        - bobcatfish
+        - dibbles
+        - dlorenc
+        - mnuttall
+        - skaegi
+        - a-roberts
+        members:
+        - SM43
+        - Megan-Wright
+        - yuege01
+        - mnuttall
+        - jessm12
+        - dibbles
+        - sthaha
+        - ImJasonH
+        - wlynch
+        - iancoffey
+        - ncskier
+        - a-roberts
+        - PuneetPunamiya
+        - vdemeester
+        - pratap0007
+        - XinruZhang
+        - YolandaDu1997
+        - akihikokuroda
+        - carlos-logro
+        privacy: closed
+        repos:
+          experimental: read
+      plumbing.collaborators:
+        description: The plumbing collaborators
+        maintainers:
+        - savitaashture
+        - abayer
+        - bobcatfish
+        - sbwsg
+        - dlorenc
+        - jerop
+        - afrittoli
+        - nikhil-thomas
+        - vdemeester
+        - kimsterv
+        - dibyom
+        - wlynch
+        members:
+        - savitaashture
+        - SM43
+        - danielhelfand
+        - bobcatfish
+        - chmouel
+        - dlorenc
+        - vdemeester
+        - piyush-garg
+        - afrittoli
+        - sbwsg
+        - dibyom
+        - wlynch
+        privacy: closed
+        repos:
+          plumbing: read
+      cli.collaborators:
+        description: The cli collaborators
+        maintainers:
+        - bobcatfish
+        - danielhelfand
+        - chmouel
+        - pradeepitm12
+        - sthaha
+        - hrishin
+        - piyush-garg
+        - vdemeester
+        members:
+        - savitaashture
+        - Divyansh42
+        - danielhelfand
+        - khrm
+        - 16yuki0702
+        - waveywaves
+        - pradeepitm12
+        - chmouel
+        - sthaha
+        - praveen4g0
+        - vdemeester
+        - hrishin
+        - piyush-garg
+        - afrittoli
+        - vinamra28
+        privacy: closed
+        repos:
+          cli: read
+      catalog.collaborators:
+        description: The catalog collaborators
+        maintainers:
+        - bobcatfish
+        - chmouel
+        - sbwsg
+        - dlorenc
+        - vdemeester
+        - kimsterv
+        - ImJasonH
+        members:
+        - Divyansh42
+        - bobcatfish
+        - SM43
+        - yuege01
+        - popcor255
+        - garethr
+        - jjasghar
+        - navidshaikh
+        - chmouel
+        - dlorenc
+        - piyush-garg
+        - sbwsg
+        - ImJasonH
+        - iancoffey
+        - PuneetPunamiya
+        - pratap0007
+        - vincent-pli
+        - vinamra28
+        - vdemeester
+        - akihikokuroda
+        - fhopfensperger
+        privacy: closed
+        repos:
+          catalog: read
+      triggers.collaborators:
+        description: The triggers collaborators
+        maintainers:
+        - bobcatfish
+        - khrm
+        - dlorenc
+        - iancoffey
+        - vtereso
+        - ncskier
+        - dibyom
+        - wlynch
+        members:
+        - savitaashture
+        - gabemontero
+        - bobcatfish
+        - khrm
+        - vincent-pli
+        - bigkevmcd
+        - dlorenc
+        - mattmoor
+        - iancoffey
+        - akihikokuroda
+        - ncskier
+        - vdemeester
+        - piyush-garg
+        - dorismeixing
+        - afrittoli
+        - dibyom
+        - wlynch
+        privacy: closed
+        repos:
+          triggers: read
+      operator.collaborators:
+        description: The operator collaborators
+        maintainers:
+        - vincent-pli
+        - houshengbo
+        - sthaha
+        - nikhil-thomas
+        - vdemeester
+        members:
+        - houshengbo
+        - vdemeester
+        - nikhil-thomas
+        - vincent-pli
+        privacy: closed
+        repos:
+          operator: read
+      friends.collaborators:
+        description: The friends collaborators
+        maintainers:
+        - bobcatfish
+        members:
+        - bobcatfish
+        privacy: closed
+        repos:
+          friends: read
+      homebrew-tools.collaborators:
+        description: The homebrew-tools collaborators
+        maintainers:
+        - bobcatfish
+        - danielhelfand
+        - chmouel
+        - pradeepitm12
+        - sthaha
+        - hrishin
+        - piyush-garg
+        - vdemeester
+        members:
+        - chmouel
+        privacy: closed
+        repos:
+          homebrew-tools: read
+      hub.collaborators:
+        description: The hub collaborators
+        maintainers:
+        - SM43
+        - sthaha
+        - pratap0007
+        - PuneetPunamiya
+        - vdemeester
+        members:
+        - PuneetPunamiya
+        - SM43
+        - pratap0007
+        - sthaha
+        privacy: closed
+        repos:
+          hub: read
+      chains.collaborators:
+        description: The chains collaborators
+        maintainers:
+        - mpeters
+        - skelterjohn
+        - lukehinds
+        - dlorenc
+        - font
+        - vdemeester
+        members:
+        - dlorenc
+        privacy: closed
+        repos:
+          chains: read

--- a/org/requirements.txt
+++ b/org/requirements.txt
@@ -1,0 +1,2 @@
+ruamel.yaml==0.16.12
+PyGithub==1.53


### PR DESCRIPTION
Create a collaborators team for every repo. Individuals in the
collaborators team have read access granted, same as the current
level of access that is provided org wide to all individuals that
belong to the org.

Every individual with read (or more) access to a repo is considered
a collaborator by GitHub; the list of collaborator is what the
/lgtm prow plugin uses to determin if an individual is allowed
to /lgtm a patch.

Ultimately, these team of collaborators aim to give more
granularity in how access to /lgtm is granted, from the whole
GitHub org to project specific, which is more in line with the
spirit of the lgtm plugin:
https://github.com/kubernetes/test-infra/blob/master/prow/plugins/approve/approvers/README.md#lgtm-label

The teams of collaborators have been created using a script
that looks for individuals that contributed 5+ commits ever to
a specific repo and who belong to the Tekton org. Hopefully this
approach will ensure that noone is affected in their daily work
by this change.

Until the organization default access setting is flipped from
read to none, everyone in the org will continue to have lgtm
on all repos. The idea is to fine-tune the list for some time
after this PR is merge, and then flip the switch.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>