### PR TITLE
Remove lucperkins from website maintainers

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -287,7 +287,6 @@ orgs:
         - vdemeester
         - kimsterv
         - abayer
-        - lucperkins
         - afrittoli
         - skaegi
         - AlanGreene


### PR DESCRIPTION
lucperkins is in the OWNERS file for tektoncd/website, however
they're not part of the tektoncd org, which breaks periobolos,
so removing them from the website.maintainers group.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>