### PR TITLE
Fix collaborators groups

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -282,7 +282,6 @@ orgs:
         maintainers:
         - bobcatfish
         members:
-        - bobcatfish
         - dlorenc
         - vdemeester
         - kimsterv
@@ -299,67 +298,60 @@ orgs:
         description: The core collaborators
         maintainers:
         - bobcatfish
-        - sbwsg
-        - dlorenc
-        - afrittoli
-        - vdemeester
-        - pritidesai
-        - dibyom
-        - ImJasonH
         members:
-        - EliZucker
-        - barthy1
-        - bobcatfish
-        - houshengbo
-        - dibyom
+        - sbwsg
         - savitaashture
-        - dibbles
-        - danielhelfand
-        - chmouel
-        - dlorenc
+        - barthy1
+        - FogDong
+        - waveywaves
         - sthaha
-        - withlin
+        - abayer
+        - shashwathi
+        - skaegi
+        - nader-ziada
+        - AlanGreene
+        - wlynch
+        - dlorenc
+        - dibbles
+        - pritidesai
+        - jerop
         - GregDritschler
+        - danielhelfand
+        - jlpettersson
+        - dibyom
         - Peaorl
         - piyush-garg
-        - AlanGreene
-        - afrittoli
-        - sbwsg
-        - wlynch
-        - ImJasonH
-        - abayer
-        - jlpettersson
-        - dwnusbaum
-        - waveywaves
-        - mattmoor
-        - jerop
-        - sergetron
-        - othomann
-        - hrishin
-        - FogDong
-        - vincent-pli
-        - vdemeester
+        - chmouel
         - psschwei
-        - skaegi
-        - shashwathi
-        - pritidesai
-        - nader-ziada
+        - sergetron
+        - hrishin
+        - ImJasonH
+        - EliZucker
+        - vdemeester
+        - mattmoor
+        - dwnusbaum
+        - othomann
+        - houshengbo
+        - vincent-pli
+        - withlin
+        - afrittoli
         privacy: closed
         repos:
           pipeline: read
       website.collaborators:
         description: The website collaborators
         maintainers:
-        - bobcatfish
+        - abayer
+        - ImJasonH
         members:
-        - bobcatfish
-        - sergetron
-        - popcor255
-        - skaegi
-        - afrittoli
-        - AlanGreene
-        - vdemeester
         - jjasghar
+        - AlanGreene
+        - popcor255
+        - afrittoli
+        - sergetron
+        - bobcatfish
+        - vdemeester
+        - skaegi
         privacy: closed
         repos:
           website: read
@@ -368,76 +360,70 @@ orgs:
         maintainers:
         - bobcatfish
         members:
-        - bobcatfish
-        - SM43
-        - CarolynMabbott
-        - mnuttall
-        - houshengbo
-        - font
-        - dibyom
-        - eddycharly
-        - savitaashture
-        - dibbles
-        - danielhelfand
-        - chmouel
-        - pradeepitm12
-        - lukehinds
-        - dlorenc
-        - sthaha
-        - piyush-garg
-        - AlanGreene
-        - afrittoli
         - sbwsg
-        - wlynch
-        - ImJasonH
+        - savitaashture
         - abayer
-        - khrm
-        - skelterjohn
+        - sthaha
         - iancoffey
-        - jerop
-        - vtereso
-        - ncskier
-        - hrishin
         - a-roberts
-        - steveodonovan
-        - PuneetPunamiya
-        - vdemeester
-        - kimsterv
-        - vincent-pli
-        - pratap0007
-        - mpeters
+        - eddycharly
         - skaegi
-        - nikhil-thomas
+        - pradeepitm12
+        - khrm
+        - pratap0007
+        - kimsterv
+        - AlanGreene
+        - wlynch
+        - dlorenc
+        - CarolynMabbott
+        - dibbles
         - pritidesai
+        - mnuttall
+        - nikhil-thomas
+        - jerop
+        - SM43
+        - dibyom
+        - danielhelfand
+        - steveodonovan
+        - skelterjohn
+        - chmouel
+        - piyush-garg
+        - vtereso
+        - font
+        - ncskier
+        - ImJasonH
+        - vdemeester
+        - hrishin
+        - lukehinds
+        - PuneetPunamiya
+        - houshengbo
+        - vincent-pli
+        - mpeters
+        - afrittoli
         privacy: closed
         repos:
           community: read
       dashboard.collaborators:
         description: The dashboard collaborators
         maintainers:
+        - abayer
+        - afrittoli
         - bobcatfish
-        - dibbles
-        - CarolynMabbott
-        - mnuttall
-        - skaegi
-        - a-roberts
-        - steveodonovan
-        - AlanGreene
-        - eddycharly
+        - ImJasonH
         members:
-        - dibbles
-        - CarolynMabbott
+        - steveodonovan
         - Megan-Wright
+        - carlos-logro
+        - AlanGreene
+        - ncskier
+        - CarolynMabbott
+        - dibbles
         - mnuttall
         - akihikokuroda
-        - skaegi
-        - ncskier
         - a-roberts
-        - steveodonovan
-        - AlanGreene
         - vdemeester
+        - skaegi
         - jessm12
-        - carlos-logro
         privacy: closed
         repos:
           dashboard: read
@@ -445,175 +431,144 @@ orgs:
         description: The experimental collaborators
         maintainers:
         - abayer
+        - afrittoli
         - bobcatfish
-        - dibbles
-        - dlorenc
-        - mnuttall
-        - skaegi
-        - a-roberts
         members:
-        - SM43
-        - Megan-Wright
-        - yuege01
-        - mnuttall
-        - jessm12
-        - dibbles
-        - sthaha
-        - ImJasonH
-        - wlynch
-        - iancoffey
-        - ncskier
-        - a-roberts
-        - PuneetPunamiya
-        - vdemeester
-        - pratap0007
-        - XinruZhang
-        - YolandaDu1997
-        - akihikokuroda
         - carlos-logro
+        - sthaha
+        - iancoffey
+        - a-roberts
+        - yuege01
+        - pratap0007
+        - Megan-Wright
+        - wlynch
+        - dibbles
+        - SM43
+        - mnuttall
+        - YolandaDu1997
+        - ncskier
+        - XinruZhang
+        - akihikokuroda
+        - ImJasonH
+        - vdemeester
+        - jessm12
+        - PuneetPunamiya
         privacy: closed
         repos:
           experimental: read
       plumbing.collaborators:
         description: The plumbing collaborators
         maintainers:
-        - savitaashture
         - abayer
-        - bobcatfish
-        - sbwsg
-        - dlorenc
-        - jerop
-        - afrittoli
-        - nikhil-thomas
-        - vdemeester
-        - kimsterv
-        - dibyom
-        - wlynch
+        - ImJasonH
         members:
+        - vdemeester
+        - sbwsg
+        - dibyom
+        - danielhelfand
+        - piyush-garg
+        - chmouel
+        - wlynch
+        - dlorenc
         - savitaashture
         - SM43
-        - danielhelfand
         - bobcatfish
-        - chmouel
-        - dlorenc
-        - vdemeester
-        - piyush-garg
         - afrittoli
-        - sbwsg
-        - dibyom
-        - wlynch
         privacy: closed
         repos:
           plumbing: read
       cli.collaborators:
         description: The cli collaborators
         maintainers:
+        - abayer
         - bobcatfish
-        - danielhelfand
-        - chmouel
-        - pradeepitm12
-        - sthaha
-        - hrishin
-        - piyush-garg
-        - vdemeester
+        - ImJasonH
         members:
-        - savitaashture
         - Divyansh42
-        - danielhelfand
-        - khrm
-        - 16yuki0702
-        - waveywaves
         - pradeepitm12
-        - chmouel
-        - sthaha
-        - praveen4g0
+        - khrm
         - vdemeester
-        - hrishin
+        - danielhelfand
         - piyush-garg
-        - afrittoli
+        - chmouel
+        - praveen4g0
+        - savitaashture
+        - waveywaves
+        - sthaha
         - vinamra28
+        - hrishin
+        - afrittoli
+        - 16yuki0702
         privacy: closed
         repos:
           cli: read
       catalog.collaborators:
         description: The catalog collaborators
         maintainers:
-        - bobcatfish
-        - chmouel
-        - sbwsg
-        - dlorenc
-        - vdemeester
-        - kimsterv
-        - ImJasonH
+        - abayer
+        - afrittoli
         members:
-        - Divyansh42
-        - bobcatfish
-        - SM43
-        - yuege01
-        - popcor255
-        - garethr
-        - jjasghar
-        - navidshaikh
-        - chmouel
-        - dlorenc
-        - piyush-garg
         - sbwsg
-        - ImJasonH
+        - jjasghar
         - iancoffey
-        - PuneetPunamiya
+        - yuege01
+        - Divyansh42
         - pratap0007
-        - vincent-pli
-        - vinamra28
-        - vdemeester
-        - akihikokuroda
+        - dlorenc
         - fhopfensperger
+        - SM43
+        - navidshaikh
+        - vinamra28
+        - piyush-garg
+        - popcor255
+        - chmouel
+        - akihikokuroda
+        - ImJasonH
+        - vdemeester
+        - PuneetPunamiya
+        - garethr
+        - vincent-pli
+        - bobcatfish
         privacy: closed
         repos:
           catalog: read
       triggers.collaborators:
         description: The triggers collaborators
         maintainers:
-        - bobcatfish
-        - khrm
-        - dlorenc
-        - iancoffey
-        - vtereso
-        - ncskier
-        - dibyom
-        - wlynch
+        - abayer
+        - ImJasonH
         members:
-        - savitaashture
-        - gabemontero
-        - bobcatfish
-        - khrm
-        - vincent-pli
-        - bigkevmcd
-        - dlorenc
         - mattmoor
-        - iancoffey
-        - akihikokuroda
-        - ncskier
         - vdemeester
+        - khrm
+        - dibyom
         - piyush-garg
+        - wlynch
+        - dlorenc
+        - ncskier
+        - iancoffey
+        - savitaashture
+        - bigkevmcd
+        - vincent-pli
+        - akihikokuroda
+        - bobcatfish
         - dorismeixing
         - afrittoli
-        - dibyom
-        - wlynch
+        - gabemontero
         privacy: closed
         repos:
           triggers: read
       operator.collaborators:
         description: The operator collaborators
         maintainers:
-        - vincent-pli
-        - houshengbo
-        - sthaha
-        - nikhil-thomas
-        - vdemeester
+        - abayer
+        - afrittoli
+        - bobcatfish
+        - ImJasonH
         members:
         - houshengbo
-        - vdemeester
         - nikhil-thomas
+        - vdemeester
         - vincent-pli
         privacy: closed
         repos:
@@ -621,22 +576,22 @@ orgs:
       friends.collaborators:
         description: The friends collaborators
         maintainers:
+        - abayer
+        - afrittoli
         - bobcatfish
-        members:
-        - bobcatfish
+        - ImJasonH
+        - vdemeester
+        members: []
         privacy: closed
         repos:
           friends: read
       homebrew-tools.collaborators:
         description: The homebrew-tools collaborators
         maintainers:
+        - abayer
+        - afrittoli
         - bobcatfish
-        - danielhelfand
-        - chmouel
-        - pradeepitm12
-        - sthaha
-        - hrishin
-        - piyush-garg
+        - ImJasonH
         - vdemeester
         members:
         - chmouel
@@ -646,27 +601,26 @@ orgs:
       hub.collaborators:
         description: The hub collaborators
         maintainers:
-        - SM43
-        - sthaha
-        - pratap0007
-        - PuneetPunamiya
+        - abayer
+        - afrittoli
+        - bobcatfish
+        - ImJasonH
         - vdemeester
         members:
         - PuneetPunamiya
-        - SM43
         - pratap0007
         - sthaha
+        - SM43
         privacy: closed
         repos:
           hub: read
       chains.collaborators:
         description: The chains collaborators
         maintainers:
-        - mpeters
-        - skelterjohn
-        - lukehinds
-        - dlorenc
-        - font
+        - abayer
+        - afrittoli
+        - bobcatfish
+        - ImJasonH
         - vdemeester
         members:
         - dlorenc


### PR DESCRIPTION
Removed duplicate roles. Team maintainers are not really needed
because we maintain the config via peribolos, however it's good
to have them setup for backup.

Using the governance team as default maintainer team, and take
care that no individual is both maintainer and member of any
collaborator team.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>