### PR TITLE
Set default project permission to "none"

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -10,7 +10,7 @@ orgs:
     - afrittoli
     billing_email: info@cd.foundation
     company: ''
-    default_repository_permission: read
+    default_repository_permission: none
     description: ''
     email: ''
     has_organization_projects: true


### PR DESCRIPTION
With this change, everyone in the Tekton org will stay part of the
org, but they won't be considered collaborators on a project unless
they're part of the project collaborator team.

The effectively restricts 'lgtm' to project collaborators only,
instead of being granted to everyone in the org for all repos like
it is today.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

/kind misc
/hold