### PR TITLE
Add a renumber command to the teps tool

### DIFF
--- a/teps/README.md.mustache
+++ b/teps/README.md.mustache
@@ -70,16 +70,46 @@ The TEP `OWNERS` are the **main** owners of the following projects:
 - [`hub`](https://github.com/tektoncd/hub)
 - [`operator`](https://github.com/tektoncd/operator)
 
-## Merging TEPs
+## Creating and Merging TEPs
 
-- TEP should be merge as soon as possible in the `proposed` state. As
-  soon as a general consensus is reached that the TEP, as described
-  (even if incomplete) make sense to pursue, the TEP can be
-  merged. The authors can then update the missing part in follow-up
-  pull requests and move it to `implementable`.
-- TEP should be approved by ***at least two owners*** from different
-  company. This should prevent a company to *force push* a TEP (and
-  thus a feature) in the tektoncd projects.
+To create a new TEP, use the [teps script](./tools/README.md):
+
+```shell
+$ ./teps.py new --title "The title of the TEP" -author nick1 -author nick2
+```
+
+The script will allocate a new valid TEP number, set the status
+to "proposed" and set the start and last updated dates.
+
+**Note that the picked number is not "locked" until a PR is created.
+The PR title shall be in the format `TEP-XXXX: <tep-title>`**.
+
+The initial content of the TEP should include the high level
+description and use cases, but no design. This helps for the TEP
+to be approved quickly.
+
+TEP should be merged as soon as possible in the `proposed` state. As
+soon as a general consensus is reached that the TEP, as described
+make sense to pursue, the TEP can be merged.
+The authors can then add the design and update the missing part in follow-up pull requests which moves the TEP to `implementable`.
+
+TEP should be approved by ***at least two owners*** from different
+company. This should prevent a company to *force push* a TEP (and
+thus a feature) in the tektoncd projects.
+
+### Solving TEP number conflicts
+
+The TEP PR might fail CI if a TEP number conflict is detected, or if
+there is a merge conflict in the TEP table. In case that happens, use
+the `teps.py renumber` command to refresh your PR:
+
+```
+./teps.py renumber --update-table <path-to-tep-file>
+```
+
+The command will update the TEP in the file name and content with a new
+available TEP number, it will refresh the TEPs table and it will present
+a list of git commands that can be used to update the commit.
 
 ## TEPs
 
@@ -88,5 +118,5 @@ This is the complete list of Tekton teps:
 | TEP  | Title  | Status   | Last Updated  |
 |------|--------|----------|---------------|
 {{#teps}}
-|[{{number}}]({{link}}) | {{title}} | {{status}} | {{lastupdated}} |
+|[{{number}}]({{link}}) | {{title}} | {{status}} | {{last-updated}} |
 {{/teps}}

--- a/teps/tools/Dockerfile
+++ b/teps/tools/Dockerfile
@@ -18,6 +18,6 @@ COPY requirements.txt .
 
 RUN pip3 install --no-cache -r requirements.txt
 COPY ./teps.py .
-COPY ./tep-template.md.mustache .
+COPY ./tep-template.md.template .
 
 CMD [ "python3", "./teps.py" ]

--- a/teps/tools/README.md
+++ b/teps/tools/README.md
@@ -4,16 +4,17 @@ The `teps.py` tool implements automation for TEPs.
 The tool support a few different commands, as well as online help:
 
 ```shell
- ./teps.py --help
+$ ./teps.py
 Usage: teps.py [OPTIONS] COMMAND [ARGS]...
 
 Options:
   --help  Show this message and exit.
 
 Commands:
-  new
-  table
-  validate
+  new       Create a new TEP with a new valid number from the template
+  renumber  Obtain a fresh TEP number and refresh the TEP and TEPs table
+  table     Generate a table of TEPs from the teps in a folder
+  validate  Validate all the TEPs in a tep
 ```
 
 ## `new`
@@ -26,11 +27,15 @@ dates and status based on the inputs provided.
 $ ./teps.py new --help
 Usage: teps.py new [OPTIONS]
 
+  Create a new TEP with a new valid number from the template
+
 Options:
-  --teps-folder TEXT  the folder that contains the TEP files
-  -t, --title TEXT    the title for the TEP in a few words
-  -a, --author TEXT   the title for the TEP in a few words
-  --help              Show this message and exit.
+  --teps-folder TEXT              the folder that contains the TEP files
+  -t, --title TEXT                the title for the TEP in a few words
+  -a, --author TEXT               the title for the TEP in a few words
+  --update-table / --no-update-table
+                                  whether to refresh the table of TEPs
+  --help                          Show this message and exit.
 ```
 
 Example:
@@ -55,7 +60,6 @@ last-updated: 2020-11-12
 status: proposed
 ---
 
-(...)
 # TEP-34: My brand new tep
 ```
 
@@ -66,6 +70,8 @@ The `table` command updates the TEP table in the README.md from the list of TEPs
 ```shell
 $ ./teps.py table --help
 Usage: teps.py table [OPTIONS]
+
+  Generate a table of TEPs from the teps in a folder
 
 Options:
   --teps-folder TEXT  the folder that contains the TEP files
@@ -82,6 +88,8 @@ The `validate` command attempts to parse all TEP files, regardless of errors, to
 ```shell
 $ ./teps.py validate --help
 Usage: teps.py validate [OPTIONS]
+
+  Validate all the TEPs in a tep
 
 Options:
   --teps-folder TEXT  the folder that contains the TEP files
@@ -104,4 +112,22 @@ No TEP number title (# TEP-NNNN) in /System/Volumes/Data/go/src/github.com/tekto
 
 $ echo $?
 1
+```
+
+## `renumber`
+
+The `renumber` obtains a new number and updates the specified TEP accordingly. This command changes the TEP filename as well as the number in the content. It optionally updates the table of TEPs too.
+
+```shell
+$ ./teps.py renumber --help
+Usage: teps.py renumber [OPTIONS]
+
+  Obtain a fresh TEP number and refresh the TEP and TEPs table
+
+Options:
+  --teps-folder TEXT              the folder that contains the TEP files
+  -f, --filename TEXT             the filename of the TEP to refresh
+  --update-table / --no-update-table
+                                  whether to refresh the table of TEPs
+  --help                          Show this message and exit.
 ```

--- a/teps/tools/requirements.txt
+++ b/teps/tools/requirements.txt
@@ -1,2 +1,3 @@
 chevron>=0.13.1
 click>=7.1.2
+ruamel.yaml==0.16.12

--- a/teps/tools/tep-template.md.template
+++ b/teps/tools/tep-template.md.template
@@ -1,13 +1,4 @@
----
-title: {{ title }}
-authors:
-{{#authors}}
-  - @{{.}}
-{{/authors}}
-creation-date: {{ created }}
-last-updated: {{ lastupdated }}
-status: {{ status }}
----
+
 <!--
 **Note:** When your TEP is complete, all of these comment blocks should be removed.
 
@@ -46,7 +37,6 @@ The canonical place for the latest set of instructions (and the likely source
 of this file) is [here](/teps/NNNN-TEP-template/README.md).
 
 -->
-# {{ number }}: {{ title }}
 
 <!--
 This is the title of your TEP.  Keep it short, simple, and descriptive.  A good


### PR DESCRIPTION
Add a renumber command that gets a new TEP number and updates a TEP
and the tep table accordingly. This can be handly in case of the
TEP number has been taken by another TEP.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>