### PR TITLE
Add a Use Cases sub-section to Motivations in the TEP template

### DIFF
--- a/teps/tools/tep-template.md.template
+++ b/teps/tools/tep-template.md.template
@@ -59,6 +59,7 @@ tags, and then generate with `hack/update-toc.sh`.
 - [Motivation](#motivation)
   - [Goals](#goals)
   - [Non-Goals](#non-goals)
+  - [Use Cases (optional)](#use-cases-optional)
 - [Requirements](#requirements)
 - [Proposal](#proposal)
   - [User Stories (optional)](#user-stories-optional)
@@ -122,6 +123,16 @@ What is out of scope for this TEP?  Listing non-goals helps to focus discussion
 and make progress.
 -->
 
+### Use Cases (optional)
+
+<!--
+Describe the concrete improvement specific groups of users will see if the
+Motivations in this doc result in a fix or feature.
+
+Consider both the user's role (are they a Task author? Catalog Task user?
+Cluster Admin? etc...) and experience (what workflows or actions are enhanced
+if this problem is solved?).
+-->
 
 ## Requirements
 


### PR DESCRIPTION
We currently have a User Stories section that give space for implementation TEPs
to describe how a specific usage will change once the implementation is complete.

For people writing a problem statement User Stories don't fit the bill since they describe
implementation specifics. This commit introduces a Use Cases sub-section to Motivation that
gives space for a TEP author to describe broad groups of users and the kinds of enhacement
they should expect from an implementation, without getting into specifics of how an
implementation could operate.