### PR TITLE
Update link to TEP template

### DIFF
--- a/teps/0001-tekton-enhancement-proposal-process.md
+++ b/teps/0001-tekton-enhancement-proposal-process.md
@@ -216,7 +216,7 @@ requirements](https://github.com/tektoncd/community/blob/master/process.md#proje
 ### TEP Template
 
 The template for a TEP is precisely defined
-[here](NNNN-tep-template/README.md)
+[here](tools/tep-template.md.template)
 
 It's worth noting, the TEP template used to track API changes will
 likely have different subsections than the template for proposing


### PR DESCRIPTION
@afrittoli does it still make sense to link to this template directly? as an author I still want to see at a glance what sections I'm gonna want to fill in, before I start writing the actual TEP (e.g. to start in a google doc), is looking at this template file still the best place to look? (mostly wondering cuz it's `.template` now)