### PR TITLE
Remove Python 3.8 syntax

### DIFF
--- a/teps/README.md
+++ b/teps/README.md
@@ -75,7 +75,7 @@ The TEP `OWNERS` are the **main** owners of the following projects:
 To create a new TEP, use the [teps script](./tools/README.md):
 
 ```shell
-$ ./teps.py new --title "The title of the TEP" -author nick1 -author nick2
+$ ./teps.py new --title "The title of the TEP" --author nick1 --author nick2
 ```
 
 The script will allocate a new valid TEP number, set the status

--- a/teps/README.md.mustache
+++ b/teps/README.md.mustache
@@ -75,7 +75,7 @@ The TEP `OWNERS` are the **main** owners of the following projects:
 To create a new TEP, use the [teps script](./tools/README.md):
 
 ```shell
-$ ./teps.py new --title "The title of the TEP" -author nick1 -author nick2
+$ ./teps.py new --title "The title of the TEP" --author nick1 --author nick2
 ```
 
 The script will allocate a new valid TEP number, set the status

--- a/teps/tools/teps.py
+++ b/teps/tools/teps.py
@@ -278,7 +278,8 @@ def validate(teps_folder):
             for field in REQUIRED_FIELDS:
                 if tep.get(field, None) is None:
                     errors.append(InvalidTep(f'{field} missing in {tep_file}'))
-            if (number := tep.get('number', '')) in tep_numbers:
+            number = tep.get('number', '')
+            if number in tep_numbers:
                 errors.append(InvalidTepNumber(f'{tep_file} uses {number} which was already in use'))
         except ValidationErrors as ve:
             errors.append(ve)


### PR DESCRIPTION
TIL about the := syntax which Python 3.8 introduced! The docs we have at
the moment say we require 3.6 (and I only have 3.7 installed personally
haha) so this commit removes the 3.8 syntax so that this script will
work with 3.6 (or at least 3.7 from my own attempts so far?).

I think in the long run we can simplify this by assuming folks will run
this via the image so they don't have to install it.

@afrittoli 