### PR TITLE
Make title argument as required

### DIFF
--- a/teps/tools/teps.py
+++ b/teps/tools/teps.py
@@ -290,7 +290,7 @@ def validate(teps_folder):
 @teps.command()
 @click.option('--teps-folder', default=LOCAL_TEP_FOLDER,
               help='the folder that contains the TEP files')
-@click.option('--title', '-t',
+@click.option('--title', '-t', required=True,
               help='the title for the TEP in a few words')
 @click.option('--author', '-a', multiple=True,
               help='the title for the TEP in a few words')


### PR DESCRIPTION
If we don't add a title the new command would crash :

```
% ./teps/tools/teps.py new
[...]
Traceback (most recent call last):
  File "..../teps/tools/teps.py", line 305, in new
    title_slug = "".join(x for x in title if x.isalnum() or x == ' ')
```