### PR TITLE
Label -> Annotation in Deprecation Strategy in TEP-0003

### DIFF
--- a/teps/0003-tekton-catalog-organization.md
+++ b/teps/0003-tekton-catalog-organization.md
@@ -562,7 +562,7 @@ A resource can be remove in the following cases (and only for those)
 * The resource has a license issue (incompatible with sharing it, …)
 
 The deprecated state of a resource is done through the
-tekton.dev/deprecated: true label.
+`tekton.dev/deprecated: "true"` annotation.
 
 ### Upstream catalogs
 


### PR DESCRIPTION
In TEP-0003 we need to add an annotation instead of
a label while deprecating a resource. So fixing the
documentation under Deprecation & Removal Strategy.

Signed-off-by: vinamra28 <vinjain@redhat.com>