### PR TITLE
[results] Create initial peribolos config.

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -263,6 +263,36 @@ orgs:
         privacy: closed
         repos:
           plumbing: write
+      results.maintainers:
+        description: the results maintainers
+        maintainers:
+        - abayer
+        - afrittoli
+        - bobcatfish
+        - ImJasonH
+        - vdemeester
+        - wlynch
+        members:
+        - dibyom
+        - ImJasonH
+        - wlynch
+        privacy: closed
+        repos:
+          results: write
+      results.collaborators:
+        description: The results collaborators
+        maintainers:
+        - abayer
+        - afrittoli
+        - bobcatfish
+        - ImJasonH
+        - vdemeester
+        - wlynch
+        members:
+        - XinruZhang
+        privacy: closed
+        repos:
+          results: read
       triggers.maintainers:
         description: the triggers maintainers
         maintainers:
@@ -631,3 +661,4 @@ orgs:
         privacy: closed
         repos:
           chains: read
+


### PR DESCRIPTION
Creates initial maintainer/collaborator team for new results project.

Primarily based on the existing OWNERS config
(https://github.com/tektoncd/results/blob/b113f90d53db800a9f6cb402fe6abc230f4ae55c/OWNERS).

For group maintainers, chose admins + wlynch.

Fixes #288 