### PR TITLE
Individuals cannot be both team maintainers and members

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -269,9 +269,7 @@ orgs:
         - abayer
         - afrittoli
         - bobcatfish
-        - ImJasonH
         - vdemeester
-        - wlynch
         members:
         - dibyom
         - ImJasonH
@@ -283,12 +281,12 @@ orgs:
         description: The results collaborators
         maintainers:
         - abayer
-        - afrittoli
         - bobcatfish
-        - ImJasonH
         - vdemeester
-        - wlynch
+        - afrittoli
         members:
+        - wlynch
+        - ImJasonH
         - XinruZhang
         privacy: closed
         repos:


### PR DESCRIPTION
Fixing groups for results maintainers and collaborators.
The maintainers section of each group is not so relevant
as we maintain the groups via peribolos anyways.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

/cc @vdemeester @wlynch 