### PR TITLE
Sync Pipeline OWNERS with org.yaml

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -177,6 +177,7 @@ orgs:
         - dlorenc
         - dibyom
         - sbwsg
+        - jerop
         privacy: closed
         repos:
           pipeline: write


### PR DESCRIPTION
Jerop was added as Pipelines Owner in https://github.com/tektoncd/pipeline/pull/3620 so needs to be added to core.maintainers in org.yaml

/cc @bobcatfish 