### PR TITLE
Spruce up user profiles 🌲

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See our standards regarding:
 
 * [Code of conduct](code-of-conduct.md)
 * [Development principles](standards.md#principles)
-* [Design principles](design-principles.md)
+* [Design principles](design-principles.md) and [User Profiles](user-profiles.md)
 * [Commit messages](standards.md#commit-messages)
 * [Go coding standards](standards.md#go)
 * [User profiles](user-profiles.md)

--- a/roadmap.md
+++ b/roadmap.md
@@ -25,14 +25,16 @@ The vision for this is:
 * Tekton API conformance across as many CI/CD platforms as possible
 * A rich catalog of high quality, reusable `Tasks` which work with Tekton conformant systems
 
-What this vision looks like differs across different users:
+What this vision looks like differs across different [users](user-profiles.md):
 
-* **Engineers building CI/CD systems**: These users will be motivated to use Tekton
-  and integrate it into the CI/CD systems they are using because building on top
-  of Tekton means they don't have to re-invent the wheel and out of the box they get
-  scalable, serverless cloud native execution
-* **Engineers who need CI/CD**: (aka all software engineers!) These users will benefit
-  from the rich high quality catalog of reusable components:
+* **Engineers building CI/CD systems**: [These users](user-profiles.md#3-platform-builder)
+  will be motivated to use Tekton and integrate it into the CI/CD systems they are using
+  because building on top of Tekton means they don't have to re-invent the wheel and out
+  of the box they get scalable, serverless cloud native execution
+* **Engineers who need CI/CD**: (aka all software engineers!) These users
+  (including [Pipeline and Task authors](user-profiles.md#2-pipeline-and-task-authors)
+  and [Pipeline and Task users](user-profiles.md#2-pipeline-and-task-users)
+  will benefit from the rich high quality catalog of reusable components:
 
   * Quickly build and interact with sophisticated `Pipelines`
   * Be able to port `Pipelines` to any Tekton conformant system

--- a/user-profiles.md
+++ b/user-profiles.md
@@ -13,21 +13,32 @@ When considering requirements and implementation solutions it's useful look at w
 
 Profiles describe a type of role a user may perform. A real person may perform more than one role and have more than one profile apply to them. How this mapping works between profiles and real people can vary between companies and other organizations. To handle this variation we focus on the user profiles rather than how they may map to people in these different organizations.
 
-### 1. Pipeline Operator
+### 1. Pipeline and Task Authors
 
-Pipeline operators define, schedule, monitor, and otherwise operate pipelines across one or more Kubernetes clusters. For example, the operation of a set of Kaniko build pipelines and Argo CD pipelines. This is not to be confused with the role of a Kubernetes cluster operator. This is also not to be confused with the application's operator role, who would oversee a product in production.
+Pipeline and Task authors are people who write Pipelines and Tasks. They may be also using them, or they may be creating Tasks and Pipelines for use by others.
 
-### 2. Pipeline Distributor
+For example:
+* Folks who maintain entries in [Tekton's Catalog](https://github.com/tektoncd/catalog) for Kaniko and ArgoCD.
+* Engineers on a platform team in a company who want to create standard Pipelines for use by multiple teams
 
-Distributors are people who package application pipelines for someone else to operate. Examples of this would be those who maintain [Tekton's Catalog](https://github.com/tektoncd/catalog) for Kaniko and ArgoCD.
+### 2. Pipeline and Task Users
+
+Pipeline and Task users are folks who find themselves actually running Pipelines and Tasks by creating or invoking tools that create, PipelineRuns and TaskRuns.
+
+For example:
+* An application developer who is focused on releasing product updates with high quality as quickly as possible may be using Tasks from [the Catalog](https://github.com/tektoncd/catalog) or provided by their company's platform team.
 
 ### 3. Platform Builder
 
-Platform builders are people who wrap Tekton's core engine and libraries to extend it. An example of this is the platform being built by [Jenkins X](https://github.com/jenkins-x/jx) using Tekton pipelines.
+Platform builders are people who wrap Tekton's core engine and libraries to extend it.
 
-### 4. Application Developer
+For example:
+* [Jenkins X](https://github.com/jenkins-x/jx)
+* A platform team at a company who chooses to create their own bespoke user experience on top of Tekton
 
-An application developer writes the software for an application. An application developer is focused on releasing product updates with high quality as quickly as possible. Examples of this include the developers of WordPress and MySQL.
+### 4. Tekton Installation Operator
+
+A Tekton installation operator administers the an installation of Tekton in a kubernetes cluster (e.g. maybe via [the Tekton Operator](https://github.com/tektoncd/operator)).
 
 ### 5. Supporting Tool Developer
 
@@ -38,16 +49,3 @@ Supporting tool developers build tools adjacent to Tekton, such as plugins, pipe
 Tekton developers are those who develop Tekton itself. That includes core maintainers along with anyone else who fixes a bug or updates docs.
 
 Generally speaking, the developers of Tekton and its interfaces consider the end users above themselves when looking at requirements and implementation strategies.
-
-## Profiles Not In Scope
-
-Some user profiles are not considered in scope for Tekton. That does not mean a real person who multiple profiles apply to is not considered a supported user. Rather, the out of scope profiles apply to roles that are not typically supported.
-
-### Cluster Operator
-
-A cluster operator stands up and operates a Kubernetes cluster. This includes elements such as the control plane, nodes, and elements in the stack below these. It does not include pipelines running on Kubernetes as those are handled by the _Pipeline Operator_ profile.
-
-### Application Operator
-
-Application operators take an application and operate it within a Kubernetes cluster. For example, the operation of WordPress and MySQL. These activities are irrelevant to Tekton unless the activity naturally intersects with Tekton as in the _Pipeline Operator_ profile.
-


### PR DESCRIPTION
In the context of some discussions with @vdemeester, I've been working
on a doc and I wanted to be able to refer to something that
distinguishes between "runtime" and "authoring time". @jerop started
working on a doc for that and I thought it would be useful to be able to
refer to the 2 (potentially) different sets of users (users at authoring
time and users at runtime) - we already had this profiles doc and it
pretty much expressed that but I thought I'd try to make it a bit more
clear.

I also changed around the 'operator' bit - I'm not sure those personas
mentioned as being out of scope were actually fully out of scope since
we do need to support folks who are operating Tekton.

Added some links to this doc from other docs as well.