### PR TITLE
Add theofpa to the org

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -109,6 +109,7 @@ orgs:
     - steveodonovan
     - sthaha
     - Tmoss11
+    - theofpa
     - vinamra28
     - vincent-pli
     - vtereso


### PR DESCRIPTION
I'd like to contribute tasks to the catalog, for example the EKS cluster create/delete tektoncd/catalog#606.