### PR TITLE
Add marcelmue to the org

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -74,6 +74,7 @@ orgs:
     - loosebazooka
     - lukehinds
     - maneeshmehra
+    - marcelmue
     - mattmoor
     - mchmarny
     - mnuttall


### PR DESCRIPTION
I have been contributing to triggers and want to be more active in the org: https://github.com/tektoncd/triggers/pulls?q=is%3Apr+author%3AMarcelMue

I would like to more easily test / work more independent for my upcoming contributions to the project.