### PR TITLE
Add Jerop and Priti as collaborators to experimental

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -486,6 +486,8 @@ orgs:
         - jessm12
         - PuneetPunamiya
         - dibyom
+        - pritidesai
+        - jerop
         privacy: closed
         repos:
           experimental: read


### PR DESCRIPTION
Jerop and Priti are both owners of the new experimental project
CELRun; for that they need to be collaborators of the overall
experimental repo.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>