### PR TITLE
Add concaf and rupalibehera to the org

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -39,6 +39,7 @@ orgs:
     - chanseokoh
     - chetan-rns
     - chmouel
+    - concaf
     - danielhelfand
     - dibbles
     - dibyom
@@ -96,6 +97,7 @@ orgs:
     - psschwei
     - raffamendes
     - rhuss
+    - rupalibehera
     - savitaashture
     - sbwsg
     - sclevine
@@ -668,4 +670,3 @@ orgs:
         privacy: closed
         repos:
           chains: read
-


### PR DESCRIPTION
- Shubbam (@concaf) is part of the OpenShift Pipelines team and is
  gonna work on several tekton projects, starting with the Operator.
- Rupali (@rupalibehera) is part of the OpenShift Pipelines team and
  is gonna work on several tekton projects, starting with the cli.

I, @vdemeester, endorse them 😉 

/cc @afrittoli @bobcatfish @ImJasonH 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>