### PR TITLE
Add Ziheng to dashboard.collaborators

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -457,6 +457,7 @@ orgs:
         - vdemeester
         - skaegi
         - jessm12
+        - ziheng
         privacy: closed
         repos:
           dashboard: read


### PR DESCRIPTION
Ziheng is on my team at IBM and will be working with me on the Dashboard.
Add him to the collaborators team so he can be assigned for reviews etc.

He has already been added to the `reviewers` list in https://github.com/tektoncd/dashboard/blob/e3ea330a781ed764120cb993960431df03e6ef68/OWNERS#L16

@ziheng fyi, see discussion on Slack: https://tektoncd.slack.com/archives/CJ4ERJWAU/p1611239123001800