### PR TITLE
A couple small tep tool changes 🔧

### DIFF
--- a/teps/README.md
+++ b/teps/README.md
@@ -75,7 +75,7 @@ The TEP `OWNERS` are the **main** owners of the following projects:
 To create a new TEP, use the [teps script](./tools/README.md):
 
 ```shell
-$ ./teps.py new --title "The title of the TEP" --author nick1 --author nick2
+$ ./teps/tools/teps.py new --title "The title of the TEP" --author nick1 --author nick2
 ```
 
 The script will allocate a new valid TEP number, set the status

--- a/teps/tools/teps.py
+++ b/teps/tools/teps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2020 The Tekton Authors
 #


### PR DESCRIPTION
- Use the full path to the script in the doc so you can copy paste the
  command
- Updated the shebang to use python3 (which is also used in the example
  README) - on my machine at least, `python` defaults to 2