### PR TITLE
TEP-0045: WhenExpressions in Finally Tasks - Change Status to Implementable

### DIFF
--- a/teps/README.md
+++ b/teps/README.md
@@ -148,4 +148,4 @@ This is the complete list of Tekton teps:
 |[TEP-0035](0035-document-tekton-position-around-policy-authentication-authorization.md) | document-tekton-position-around-policy-authentication-authorization | implementable | 2020-12-09 |
 |[TEP-0036](0036-start-measuring-tekton-pipelines-performance.md) | Start Measuring Tekton Pipelines Performance | proposed | 2020-11-20 |
 |[TEP-0037](0037-remove-gcs-fetcher.md) | Remove `gcs-fetcher` image | proposed | 2021-01-27 |
-|[TEP-0045](0045-whenexpressions-in-finally-tasks.md) | WhenExpressions in Finally Tasks | proposed | 2021-01-27 |
+|[TEP-0045](0045-whenexpressions-in-finally-tasks.md) | WhenExpressions in Finally Tasks | implementable | 2021-01-28 |


### PR DESCRIPTION
We proposed supporting WhenExpressions in Finally Tasks in https://github.com/tektoncd/community/pull/317, and the TEP has a proposed status now

TEP: https://github.com/tektoncd/community/blob/master/teps/0045-whenexpressions-in-finally-tasks.md

In this PR, we want to change TEP status to implementable and update the examples provided for using `Execution Status`, `Results` and `Parameters`

/cc @sbwsg @pritidesai 