### PR TITLE
Update pipeline reference from master to main 🧙

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -5,7 +5,7 @@ This doc describes Tekton's mission and the 2020 roadmap.
 - [Mission and Vision](#mission-and-vision)
 - [2021 Roadmap](#2021-roadmap)
 - Tekton Project Roadmaps
-  - [Pipeline](https://github.com/tektoncd/pipeline/blob/master/roadmap.md)
+  - [Pipeline](https://github.com/tektoncd/pipeline/blob/main/roadmap.md)
   - [Triggers](https://github.com/tektoncd/triggers/blob/main/roadmap.md)
   - [Catalog](https://github.com/tektoncd/catalog/blob/master/roadmap.md)
   - [Dashboard](https://github.com/tektoncd/dashboard/blob/main/roadmap.md)

--- a/standards.md
+++ b/standards.md
@@ -117,7 +117,7 @@ _See also [the Tekton review process](https://github.com/tektoncd/community/blob
       it would make sense to move the test into another package and export it
 * Test code
   * When using cmp.Diff the argument order is always (want, got) and in the error message include (-want +got)
-    (and/or use a lib like [PrintWantGot](https://github.com/tektoncd/pipeline/blob/master/test/diff/print.go))
+    (and/or use a lib like [PrintWantGot](https://github.com/tektoncd/pipeline/blob/main/test/diff/print.go))
   * Table driven tests: do not use the same test for success and fail cases if the logic is different
     (e.g. do not have two sets of test logic, gated with `wantErr`)
 

--- a/teps/0001-tekton-enhancement-proposal-process.md
+++ b/teps/0001-tekton-enhancement-proposal-process.md
@@ -409,7 +409,7 @@ We are now switching to the "Implementing Tekton Bundles" TEP.
 See the following links for more context on this feature:
 
 - [Tekton Pipeline Resource Extensibility](https://docs.google.com/document/d/1rcMG1cIFhhixMSmrT734MBxvH3Ghre9-4S2wbzodPiU/edit#)
-- [Why Aren't PipelineResources in Beta ?](https://github.com/tektoncd/pipeline/blob/master/docs/resources.md#why-arent-pipelineresources-in-beta)
+- [Why Aren't PipelineResources in Beta ?](https://github.com/tektoncd/pipeline/blob/main/docs/resources.md#why-arent-pipelineresources-in-beta)
 - [Pipeline Reosurces Redesign](https://github.com/tektoncd/pipeline/issues/1673)
 
 1. A TEP is proposed to add extensibility to PipelineResources. This

--- a/teps/0007-conditions-beta.md
+++ b/teps/0007-conditions-beta.md
@@ -56,7 +56,7 @@ Original Design Doc in Google Docs, visible to members of tekton-dev@: https://d
 
 ## Summary
 
-`Conditions` is a [CRD](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) used to specify a criteria to determine whether or not a `Task` executes. When other Tekton resources were migrated to [beta](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#alpha-beta-and-ga), it remained in [alpha](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#alpha-beta-and-ga) because it was missing features needed by users.
+`Conditions` is a [CRD](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) used to specify a criteria to determine whether or not a `Task` executes. When other Tekton resources were migrated to [beta](https://github.com/tektoncd/pipeline/blob/main/api_compatibility_policy.md#alpha-beta-and-ga), it remained in [alpha](https://github.com/tektoncd/pipeline/blob/main/api_compatibility_policy.md#alpha-beta-and-ga) because it was missing features needed by users.
 
 After analyzing the feature requests and discussing with users, we have identified that the most critical gaps in `Conditions` are **simplicity**, **efficiency**, **skipping** and **status**. We want to address these gaps so that it can work well with the other `Pipeline` resources and users can count on its stability.
 

--- a/teps/0021-results-api.md
+++ b/teps/0021-results-api.md
@@ -685,7 +685,7 @@ needs.
 ### Naming overlap with Task results
 
 There is naming overlap with
-[Task outputs](https://github.com/tektoncd/pipeline/blob/master/docs/tasks.md#emitting-results),
+[Task outputs](https://github.com/tektoncd/pipeline/blob/main/docs/tasks.md#emitting-results),
 called Task results. There is a risk that users may confuse Tekton Results with
 Task results.
 
@@ -731,7 +731,7 @@ behavior or add a feature that may replace and deprecate a current one.
 -->
 
 We will be consistent with the Pipelines
-[API compatibility policy](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) -
+[API compatibility policy](https://github.com/tektoncd/pipeline/blob/main/api_compatibility_policy.md) -
 tl;dr free to make breaking changes in alpha, breaking changes are allowed with
 a deprecation period in beta, and no breaking changes allowed in stable (i.e.
 v1).

--- a/teps/0024-embedded-trigger-templates.md
+++ b/teps/0024-embedded-trigger-templates.md
@@ -33,7 +33,7 @@ resources makes it simple (and less verbose) to express workflows in Tekton.
 This is especially true for simple use cases, examples, and documentation where
 reusability is less of a concern. For instance, Task specs can be embedded
 inside TaskRuns (see the
-[examples](https://github.com/tektoncd/pipeline/tree/master/examples/v1beta1/taskruns)).
+[examples](https://github.com/tektoncd/pipeline/tree/main/examples/v1beta1/taskruns)).
 
 Within a Trigger, at the moment, only `bindings` can be embedded while Templates
 always have to be referenced. Allowing embedded templates will make it easier

--- a/teps/0028-task-execution-status-at-runtime.md
+++ b/teps/0028-task-execution-status-at-runtime.md
@@ -102,7 +102,7 @@ All necessary e2e and unit tests will be added.
 ## Alternatives
 
 * If the states defined in this [Proposal](#proposal) are not clear, one alternative is to change these states and align them
-to `pipelineRun` [execution status](https://github.com/tektoncd/pipeline/blob/master/docs/pipelineruns.md#monitoring-execution-status) (`Unknown`, `True`, `False`). Also change the proposed variable pattern to match these states.
+to `pipelineRun` [execution status](https://github.com/tektoncd/pipeline/blob/main/docs/pipelineruns.md#monitoring-execution-status) (`Unknown`, `True`, `False`). Also change the proposed variable pattern to match these states.
 
 * Another alternative is to add more states such as `Started`, `Running`, and `Cancelled` if the proposed states are
 not sufficient for your use cases.

--- a/teps/0029-step-workspaces.md
+++ b/teps/0029-step-workspaces.md
@@ -220,7 +220,7 @@ of a temporary `authorized_keys` file which in turn allows the Steps to successf
 the Sidecar over SSH.
 
 For an existing example where this could be useful, see the
-[authenticating-git-commands](https://github.com/tektoncd/pipeline/blob/master/examples/v1beta1/taskruns/authenticating-git-commands.yaml)
+[authenticating-git-commands](https://github.com/tektoncd/pipeline/blob/main/examples/v1beta1/taskruns/authenticating-git-commands.yaml)
 example from the Pipelines repo.
 
 #### Story 4

--- a/teps/0030-workspace-paths.md
+++ b/teps/0030-workspace-paths.md
@@ -147,7 +147,7 @@ workspace. Here's an example from our catalog:
 _and_ the files that are expected to be received on them. Example from
 [recent `tkn` PR](https://github.com/tektoncd/catalog/pull/499/files#diff-6752c482b505c3f8ffed15a7d7d291b5R20-R23):
 
-    > - **kubeconfig**: An [optional workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md#using-workspaces-in-tasks)
+    > - **kubeconfig**: An [optional workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md#using-workspaces-in-tasks)
     > that allows you to provide a `.kube/config` file for `tkn` to access the cluster.
     > The file should be placed at the root of the Workspace with name `kubeconfig`.
 

--- a/teps/0035-document-tekton-position-around-policy-authentication-authorization.md
+++ b/teps/0035-document-tekton-position-around-policy-authentication-authorization.md
@@ -79,7 +79,7 @@ if need be and bring it up.
 
 ## Motivation
 
-As noted at the top of the [Tekton Pipelines README.md](https://github.com/tektoncd/pipeline/blob/master/README.md),
+As noted at the top of the [Tekton Pipelines README.md](https://github.com/tektoncd/pipeline/blob/main/README.md),
 the first of its main, high level, advantages is that Tekton is Cloud Native, implemented as Kubernetes, and thus
 inherently has the ability to integrate into key Kubernetes facilities around:
 
@@ -167,13 +167,13 @@ there are sufficient third party solutions we can work with in order to meet tho
 
 ## Proposal
 
-We augment documentation, much like what exists [for Authentication](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md)
+We augment documentation, much like what exists [for Authentication](https://github.com/tektoncd/pipeline/blob/main/docs/auth.md)
 for the other typical security concerns.  Here is a current sampling of scenarios, where of course this is a moment in time snapshot,
 and perhaps not even a complete one at that (we can grow documentation iteratively of course):
 
 ### Pod Security Policy (PSP)
 
-Providing some concise background / and or details on why [the current Pod Security Policy](https://github.com/tektoncd/pipeline/blob/master/config/101-podsecuritypolicy.yaml)
+Providing some concise background / and or details on why [the current Pod Security Policy](https://github.com/tektoncd/pipeline/blob/main/config/101-podsecuritypolicy.yaml)
 has what it has could prove helpful to new users.
 
 Perhaps mine the PRs associated with the history of changes.  Avoid simply repeating k8s documentation for the fields.

--- a/teps/0037-remove-gcs-fetcher.md
+++ b/teps/0037-remove-gcs-fetcher.md
@@ -23,7 +23,7 @@ status: implementing
 
 ## Summary
 
-Every Tekton Pipelines release builds and bundles an image, `gcs-fetcher`, which is vendored from https://github.com/GoogleCloudPlatform/cloud-builders/blob/master/gcs-fetcher. This image exists to support the [BuildGCS Storage Resource](https://github.com/tektoncd/pipeline/blob/master/docs/resources.md#buildgcs-storage-resource). That is, the image is involved when the user configures a `storage`-type `PipelineResource`, with a `type` of `build-gcs`.
+Every Tekton Pipelines release builds and bundles an image, `gcs-fetcher`, which is vendored from https://github.com/GoogleCloudPlatform/cloud-builders/blob/master/gcs-fetcher. This image exists to support the [BuildGCS Storage Resource](https://github.com/tektoncd/pipeline/blob/main/docs/resources.md#buildgcs-storage-resource). That is, the image is involved when the user configures a `storage`-type `PipelineResource`, with a `type` of `build-gcs`.
 
 Tekton Pipelines doesn't collect centralized usage metrics, but I personally believe this functionality is not used. If it _is_ used, the only functionality it provides beyond the `gcs`-type `PipelineResource` is in supporting [Source Manifests](https://github.com/GoogleCloudPlatform/cloud-builders/tree/master/gcs-fetcher#source-manifests), which I believe nobody does today.
 
@@ -35,7 +35,7 @@ I would like to remove support for the `build-gcs` `PipelineResource`.
 
 Building and releasing an image in Tekton's core upstream repo induces release and maintenance burden on all downstream teams. So far this burden has been relatively light, but nobody knows when you might find a critical CVE or crashing bug in unused legacy behavior.
 
-Support for the `build-gcs` `PipelineResource` was added to ease the transition of [Knative Build](https://github.com/knative/build) users [migrating to Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/migrating-from-knative-build.md). I believe Source Manifest usage was low even back when Knative Build was a thing, let alone nearly eighteen months later.
+Support for the `build-gcs` `PipelineResource` was added to ease the transition of [Knative Build](https://github.com/knative/build) users [migrating to Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/main/docs/migrating-from-knative-build.md). I believe Source Manifest usage was low even back when Knative Build was a thing, let alone nearly eighteen months later.
 
 Given the assumption of low utility and non-zero cost, and the potential of higher future cost, we should bias toward action in removing support.
 
@@ -55,7 +55,7 @@ This proposal does not intend to remove support for the `gcs`-type `PipelineReso
 
 When this proposal is marked `implementing`, attempt to notify Tekton users and operators to let them know the deprecation is coming, and ask for feedback. This includes posting to `tekton-users@`, the Tekton Slack, weekly WG meetings, and, if need be, me personally shouting it from my balcony.
 
-Assuming no negative response from that communication, update [the docs](https://github.com/tektoncd/pipeline/blob/master/docs/resources.md#gcs-storage-resource) to note that support will be deprecated in the next release (currently, v1.21).
+Assuming no negative response from that communication, update [the docs](https://github.com/tektoncd/pipeline/blob/main/docs/resources.md#gcs-storage-resource) to note that support will be deprecated in the next release (currently, v1.21).
 
 Assuming no negative response, after the v1.21 release branch is cut, remove support for `build-crd` and remove `gcs-fetcher` from the Tekton Pipelines codebase.
 

--- a/teps/0045-whenexpressions-in-finally-tasks.md
+++ b/teps/0045-whenexpressions-in-finally-tasks.md
@@ -103,10 +103,10 @@ updates.
 [documentation style guide]: https://github.com/kubernetes/community/blob/master/contributors/guide/style-guide.md
 -->
 
-Users can guard execution of `Tasks` using `WhenExpressions`, but that is not supported in `Finally Tasks`. This TEP 
+Users can guard execution of `Tasks` using `WhenExpressions`, but that is not supported in `Finally Tasks`. This TEP
 describes the need for supporting `WhenExpressions` in `Finally Tasks` not only to provide efficient guarded execution
-but also to improve the reusability of `Tasks`. Given we've recently added support for `Results` and `Status` in 
-`Finally Tasks`, this is an opportune time to enable `WhenExpressions` in `Finally Tasks`. 
+but also to improve the reusability of `Tasks`. Given we've recently added support for `Results` and `Status` in
+`Finally Tasks`, this is an opportune time to enable `WhenExpressions` in `Finally Tasks`.
 
 ## Motivation
 
@@ -119,19 +119,19 @@ demonstrate the interest in a TEP within the wider Tekton community.
 [experience reports]: https://github.com/golang/go/wiki/ExperienceReports
 -->
 
-Currently, users cannot guard the execution of `Finally Tasks` so they are always executed. 
-Users may want to guard the execution of `Finally Tasks` based on [`Results` from other `Tasks`](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md#consuming-task-execution-results-in-finally). 
-Moreover, now that [the execution status of `Tasks` is accessible in `Finally Tasks`](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md#using-execution-status-of-pipelinetask),
+Currently, users cannot guard the execution of `Finally Tasks` so they are always executed.
+Users may want to guard the execution of `Finally Tasks` based on [`Results` from other `Tasks`](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#consuming-task-execution-results-in-finally).
+Moreover, now that [the execution status of `Tasks` is accessible in `Finally Tasks`](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#using-execution-status-of-pipelinetask),
 they may also want to guard the execution of `Finally Tasks` based on the execution status of other `Tasks`.
 
-An example use case is a `Pipeline` author wants to send a notification, such as posting on Slack using [this catalog task](https://github.com/tektoncd/catalog/tree/master/task/send-to-channel-slack/0.1#post-a-message-to-slack), 
+An example use case is a `Pipeline` author wants to send a notification, such as posting on Slack using [this catalog task](https://github.com/tektoncd/catalog/tree/master/task/send-to-channel-slack/0.1#post-a-message-to-slack),
 when a certain `Task` in the `Pipeline` failed. To do this, one user has had to use a workaround using `Workspaces` that
 they describe [in this thread](https://tektoncd.slack.com/archives/CK3HBG7CM/p1603399989171300?thread_ts=1603376439.161500&cid=CK3HBG7CM).
 In addition, needing the workaround prevents the user from reusing the Slack catalog task as further described in [this issue](https://github.com/tektoncd/pipeline/issues/3438).
 
-We already guard `Tasks` using [`WhenExpressions`](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md#guard-task-execution-using-whenexpressions),
-which efficiently evaluate the criteria of executing `Tasks`. We propose supporting using `WhenExpressions` to guard 
-the execution of `Finally Tasks` as well. 
+We already guard `Tasks` using [`WhenExpressions`](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#guard-task-execution-using-whenexpressions),
+which efficiently evaluate the criteria of executing `Tasks`. We propose supporting using `WhenExpressions` to guard
+the execution of `Finally Tasks` as well.
 
 ### Goals
 
@@ -142,7 +142,7 @@ know that this has succeeded?
 
 - Improve the [reusability](https://github.com/tektoncd/community/blob/main/design-principles.md#reusability)
 of `Tasks` by improving the guarding of `Finally Tasks` at authoring time.
-- Enable guarding execution of `Finally Tasks` using `WhenExpressions`.  
+- Enable guarding execution of `Finally Tasks` using `WhenExpressions`.
 
 ### Non-Goals
 
@@ -163,13 +163,13 @@ implementation.  The "Design Details" section below is for the real
 nitty-gritty.
 -->
 
-To improve reusability and support guarding of `Tasks` in `Finally`, we propose enabling `WhenExpressions` in `Finally 
-Tasks`. Similar to in non-finally `Tasks`, the `WhenExpressions` in `Finally Tasks` can operate on static inputs or 
-variables such as `Parameters`, `Results` and `Execution Status` through variable substitution. 
+To improve reusability and support guarding of `Tasks` in `Finally`, we propose enabling `WhenExpressions` in `Finally
+Tasks`. Similar to in non-finally `Tasks`, the `WhenExpressions` in `Finally Tasks` can operate on static inputs or
+variables such as `Parameters`, `Results` and `Execution Status` through variable substitution.
 
-If the `WhenExpressions` evaluate to `True`, the `Finally Task` would be executed. If the `WhenExpressions` evaluate to 
-`False`, the `Finally Task` would be skipped and included in the list of `Skipped Tasks` section of the `Status`. 
-Moreover, the `Pipeline` will exit with `Completion` instead of `Success`, as described in a [similar scenario in the docs](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md#consuming-task-execution-results-in-finally).
+If the `WhenExpressions` evaluate to `True`, the `Finally Task` would be executed. If the `WhenExpressions` evaluate to
+`False`, the `Finally Task` would be skipped and included in the list of `Skipped Tasks` section of the `Status`.
+Moreover, the `Pipeline` will exit with `Completion` instead of `Success`, as described in a [similar scenario in the docs](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#consuming-task-execution-results-in-finally).
 
 Note that this proposal does not affect the scheduling of `Finally Tasks`, they will still be executed in parallel after
 the other `Tasks` are done.
@@ -234,10 +234,10 @@ spec:
 
 If the `WhenExpressions` in a `Finally Task` use `Results` from a skipped or failed non-finally `Tasks`, then the
 `Finally Task` would also be skipped and be included in the list of `Skipped Tasks` in the `Status`, [similarly to when
-`Results` in other parts of the `Finally Task`](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md#consuming-task-execution-results-in-finally).
+`Results` in other parts of the `Finally Task`](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#consuming-task-execution-results-in-finally).
 
 We will validate the `Result` references in the `WhenExpressions` beforehand. If they are invalid (e.g. they don't
-exist or there's a typo), the `Pipeline` validation will fail upfront. 
+exist or there's a typo), the `Pipeline` validation will fail upfront.
 
 ### Using Parameters
 
@@ -269,7 +269,7 @@ spec:
             values: ["Failed"]
           - input: $(params.enable-notifications)
             operator: in
-            values: ["true"]  
+            values: ["true"]
         taskRef:
           name: send-to-slack-channel
       # […]
@@ -292,10 +292,10 @@ via CLI, dashboard or a monitoring system.
 Consider including folks that also work on CLI and dashboard.
 -->
 
-Currently, users have to build workarounds using `Workspaces` and make their `Finally Tasks`'s `Steps` implement the 
-conditional execution. By supporting `WhenExpressions` in `Finally Tasks`, we will significantly improve the user 
-experience of guarding the execution of `Finally Tasks`. Additionally, it makes it easier for users to reuse `Tasks` 
-including those provided in the [Catalog](https://github.com/tektoncd/catalog). 
+Currently, users have to build workarounds using `Workspaces` and make their `Finally Tasks`'s `Steps` implement the
+conditional execution. By supporting `WhenExpressions` in `Finally Tasks`, we will significantly improve the user
+experience of guarding the execution of `Finally Tasks`. Additionally, it makes it easier for users to reuse `Tasks`
+including those provided in the [Catalog](https://github.com/tektoncd/catalog).
 
 ### Performance
 
@@ -309,7 +309,7 @@ Consider which use cases are impacted by this change and what are their
 performance requirements.
 -->
 
-`WhenExpressions` efficiently evaluate the execution criteria without spinning up new pods. 
+`WhenExpressions` efficiently evaluate the execution criteria without spinning up new pods.
 
 ## Test Plan
 
@@ -333,18 +333,18 @@ expectations).
 
 ## Design Evaluation
 <!--
-How does this proposal affect the reusability, simplicity, flexibility 
+How does this proposal affect the reusability, simplicity, flexibility
 and conformance of Tekton, as described in [design principles](https://github.com/tektoncd/community/blob/main/design-principles.md)
 -->
 
 - [Reusability](https://github.com/tektoncd/community/blob/main/design-principles.md#reusability): This proposal reuses
   an existing component, `WhenExpressions`, to guard `Finally Tasks`. Moreover, it improves the reusability of `Tasks` by
-  enabling specifying guards explicitly and avoiding representing them in the `Tasks`'s `Steps`. 
-  
+  enabling specifying guards explicitly and avoiding representing them in the `Tasks`'s `Steps`.
+
 - [Simplicity](https://github.com/tektoncd/community/blob/main/design-principles.md#simplicity): Using `WhenExpressions`
-  to guard the execution of `Finally Tasks` is much simpler than the workarounds that used `Workspaces`. It is also 
+  to guard the execution of `Finally Tasks` is much simpler than the workarounds that used `Workspaces`. It is also
   consistent with how we already guard the other `Tasks`.
-  
+
 ## Drawbacks
 
 <!--
@@ -353,8 +353,8 @@ Why should this TEP _not_ be implemented?
 
 One could argue that this proposal breaks the `Finally` contract because a `Finally Task` would not run when its
 `WhenExpressions ` evaluate to `False`. However, the `PipelineRun` does attempt such `Finally Tasks` and is explicitly
-skipped, so it's considered `ran` by the `PipelineRun` Controller. Moreover, we are already failing `Finally Tasks` 
-that use `Results` from failed or skipped `Tasks` with validation failure. 
+skipped, so it's considered `ran` by the `PipelineRun` Controller. Moreover, we are already failing `Finally Tasks`
+that use `Results` from failed or skipped `Tasks` with validation failure.
 
 ## Alternatives
 
@@ -364,9 +364,9 @@ not need to be as detailed as the proposal, but should include enough
 information to express the idea and why it was not acceptable.
 -->
 
-- `Finally Tasks` should not be guarded so that they're always "executed" as implied by the `Finally` terminology. 
-  However, users creating workarounds to support guarding `Finally Tasks`. In addition, we already [allow skipping](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md#consuming-task-execution-results-in-finally)
-  `Finally Tasks` they use uninitialized `Results` from skipped or failed `Tasks`. 
+- `Finally Tasks` should not be guarded so that they're always "executed" as implied by the `Finally` terminology.
+  However, users creating workarounds to support guarding `Finally Tasks`. In addition, we already [allow skipping](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#consuming-task-execution-results-in-finally)
+  `Finally Tasks` they use uninitialized `Results` from skipped or failed `Tasks`.
 
 - Use `Conditions` to guard `Finally Tasks`. However, `Conditions` were deprecated and replaced with [`WhenExpressions`](https://github.com/tektoncd/community/blob/main/teps/0007-conditions-beta.md),
   read further details in [Conditions Beta TEP](https://github.com/tektoncd/community/blob/main/teps/0007-conditions-beta.md).
@@ -380,9 +380,9 @@ shared drive, examples, etc. This is useful to refer back to any other related l
 to get more details.
 -->
 
-- [TEP for `WhenExpressions`](https://github.com/tektoncd/community/blob/main/teps/0007-conditions-beta.md)  
-- [Guarding `Task` execution using `WhenExpressions`](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md#guard-task-execution-using-whenexpressions)
+- [TEP for `WhenExpressions`](https://github.com/tektoncd/community/blob/main/teps/0007-conditions-beta.md)
+- [Guarding `Task` execution using `WhenExpressions`](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#guard-task-execution-using-whenexpressions)
 - [TEP for `Tasks` `Results` in `Finally Tasks`](https://github.com/tektoncd/community/blob/main/teps/0004-task-results-in-final-tasks.md)
-- [Consuming `Tasks` `Results` in `Finally Tasks`](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md#consuming-task-execution-results-in-finally)  
+- [Consuming `Tasks` `Results` in `Finally Tasks`](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#consuming-task-execution-results-in-finally)
 - [TEP for `Task` execution status in `Finally Tasks`](https://github.com/tektoncd/community/blob/main/teps/0028-task-execution-status-at-runtime.md)
-- [Accessing `Task` execution status in `Finally Tasks`](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md#using-execution-status-of-pipelinetask)
+- [Accessing `Task` execution status in `Finally Tasks`](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#using-execution-status-of-pipelinetask)

--- a/user-profiles.md
+++ b/user-profiles.md
@@ -39,7 +39,7 @@ For example:
 #### 3a. Platform Builder Implementing the Tekton API
 
 Some platform builders may wish to create their own systems which comply to Tekton API specs (e.g.
-[the Tekton Pipelines API spec](https://github.com/tektoncd/pipeline/blob/master/docs/api-spec.md)) but use their own
+[the Tekton Pipelines API spec](https://github.com/tektoncd/pipeline/blob/main/docs/api-spec.md)) but use their own
 implementations.
 
 For example:


### PR DESCRIPTION
This updates any reference of pipeline repository to target the
main branch instead of the master branch.

/hold
/cc @bobcatfish @afrittoli @ImJasonH 

Related to tektoncd/plumbing#681

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>