### PR TITLE
Update dashboard reference from master to main 🧙

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -11,7 +11,7 @@ for Tekton Pipelines but some sneak peeks at other projects as well.
   - [Pipeline](https://github.com/tektoncd/pipeline/blob/master/roadmap.md)
   - [Triggers](https://github.com/tektoncd/triggers/blob/master/roadmap.md)
   - [Catalog](https://github.com/tektoncd/catalog/blob/master/roadmap.md)
-  - [Dashboard](https://github.com/tektoncd/dashboard/blob/master/roadmap.md)
+  - [Dashboard](https://github.com/tektoncd/dashboard/blob/main/roadmap.md)
   - [CLI](https://github.com/tektoncd/cli/blob/master/ROADMAP.md)
 
 ## Mission and Vision


### PR DESCRIPTION
This updates any reference of dashboard repository to target the
main branch instead of the master branch.

/cc @afrittoli @bobcatfish @ImJasonH 
/hold

Related to tektoncd/plumbing#681

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>