### PR TITLE
Update experimental reference from master to main 🧙

### DIFF
--- a/teps/0005-tekton-oci-bundles.md
+++ b/teps/0005-tekton-oci-bundles.md
@@ -43,7 +43,7 @@ discussed in the following docs:
 - [Tekton OCI Image Design](https://docs.google.com/document/d/1lXF_SvLwl6OqqGy8JbpSXRj4hWJ6CSImlxlIl4V9rnM/edit?pl=1#)
 
 This will be based from the knowledge acquired on the [experimental oci
-project](https://github.com/tektoncd/experimental/tree/master/oci) we ran.
+project](https://github.com/tektoncd/experimental/tree/main/oci) we ran.
 
 ## Motivation
 
@@ -405,7 +405,7 @@ expectations).
 
 We need a tool to be able to package, push and pull images to and from
 any OCI registries. The
-[`oci`](https://github.com/tektoncd/experimental/tree/master/oci)
+[`oci`](https://github.com/tektoncd/experimental/tree/main/oci)
 experimental project would be a good fit for this — before we discuss
 and integrate Tekton OCI bundles in `tkn` and the `tektoncd/pipeline`
 types.

--- a/teps/0021-results-api.md
+++ b/teps/0021-results-api.md
@@ -746,7 +746,7 @@ to get more details.
 
 - Original Project Proposal:
   https://docs.google.com/document/d/1-XBYQ4kBlCHIHSVoYAAf_iC01_by_KoK2aRVO0t8ZQ0
-- Proof of Concept: https://github.com/tektoncd/experimental/tree/master/results
+- Proof of Concept: https://github.com/tektoncd/experimental/tree/main/results
 
 ## Future Work
 


### PR DESCRIPTION
This updates any reference of experimental repository to target the
main branch instead of the master branch.

/cc @afrittoli @bobcatfish @ImJasonH 
/hold

Related to tektoncd/plumbing#681

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>