### PR TITLE
Update plumbing reference from master to main 🧙

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -160,7 +160,7 @@ Members of the governing board will be given access to these resources:
   which is used for [test and release infrastructure](https://github.com/tektoncd/plumbing)
 * [The GCP project `tekton-nightly`](http://console.cloud.google.com/home/dashboard?project=tekton-nightly)
   which is used for publishing nightly releases for Tekton projects
-* [The GCP projects used by boskos](https://github.com/tektoncd/plumbing/blob/master/boskos/boskos-config.yaml)
+* [The GCP projects used by boskos](https://github.com/tektoncd/plumbing/blob/main/boskos/boskos-config.yaml)
   which are used to test against
 
-They have the permissions added through a [script](https://github.com/tektoncd/plumbing/blob/master/addpermissions.py).
+They have the permissions added through a [script](https://github.com/tektoncd/plumbing/blob/main/addpermissions.py).

--- a/org/README.md
+++ b/org/README.md
@@ -8,7 +8,7 @@ to manage the org configuration.
 
 Changes to this configuration are applied automatically via a GitHub trigger:
 
-* https://github.com/tektoncd/plumbing/tree/master/tekton/resources/org-permissions
+* https://github.com/tektoncd/plumbing/tree/main/tekton/resources/org-permissions
 
 ## Requirements
 

--- a/standards.md
+++ b/standards.md
@@ -32,7 +32,7 @@ _See also [the Tekton review process](https://github.com/tektoncd/community/blob
   * If the template contains a checklist, it should be checked off
   * Release notes filled in for user visible changes (bugs + features),
     or removed if not applicable (refactoring, updating tests) (may be enforced
-    via the [release-note Prow plugin](https://github.com/tektoncd/plumbing/blob/master/prow/plugins.yaml))
+    via the [release-note Prow plugin](https://github.com/tektoncd/plumbing/blob/main/prow/plugins.yaml))
 
 ## Commits
 


### PR DESCRIPTION
This updates any reference of plumbing repository to target the
main branch instead of the master branch.

/cc @afrittoli @bobcatfish @ImJasonH 
/hold

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>