### PR TITLE
Update Catalog Org TEP for Version Bump condition

### DIFF
--- a/teps/0003-tekton-catalog-organization.md
+++ b/teps/0003-tekton-catalog-organization.md
@@ -5,8 +5,8 @@ authors:
   - "@sthaha"
   - "@bobcatfish"
 creation-date: 2020-06-11
-last-updated: 2020-08-12
-status: implementable
+last-updated: 2021-02-09
+status: implemented
 ---
 
 # TEP-0003: Tekton Catalog Organization
@@ -145,8 +145,8 @@ this](https://docs.google.com/document/d/1-czjvjfpuIqYKsfkvZ5RxIbtoFNLTEtOxaZB71
     3. Existing users of the resource can choose what versions of the
        resources they can use
 
-3. Updates to already published resources should be a new versioned
-   release instead of updating the existing released version.
+3. If an update change the behavior of an already published task, the updated
+   task should be a released as a new version.
 
 4. Users of the catalog can reference Tasks in the catalog in their
    TaskRuns and Pipelines including the version they would like to use
@@ -289,7 +289,7 @@ bump is necessary (taken Task as example) :
   * When the image for a step is specified via an input params, we should treat changes to the default value of that param in the same way as changes to a step image
 
 * New fields are added to the Task (new parameters, new results, new
-  workspace, new input, new output, …)
+  workspace, new input, new output, …) and they are going to affect behaviour of the task which might break the pipeline created with existing version.
 
 * The command+arg or script is changed (and the behavior) changes
 
@@ -300,7 +300,10 @@ Changes to an existing version may however be permitted to
 non-functional parts like the metadata.annotations, labels of the
 resource, README, samples, but we should strive to keep that minimal
 so that the resource definition is independent of the time it was
-applied by the user.
+applied by the user. Also, new fields can be added to existing 
+version with default values if it is not going to break pipeline 
+created with existing version. This can be ensured by running tests 
+on the updated resource.
 
 #### Open questions
 

--- a/teps/README.md
+++ b/teps/README.md
@@ -119,7 +119,7 @@ This is the complete list of Tekton teps:
 |------|--------|----------|---------------|
 |[TEP-0001](0001-tekton-enhancement-proposal-process.md) | Tekton Enhancement Proposal Process | implemented | 2020-06-11 |
 |[TEP-0002](0002-custom-tasks.md) | Custom Tasks | implementable | 2020-07-07 |
-|[TEP-0003](0003-tekton-catalog-organization.md) | Tekton Catalog Organization | implementable | 2020-08-12 |
+|[TEP-0003](0003-tekton-catalog-organization.md) | Tekton Catalog Organization | implemented | 2021-02-09 |
 |[TEP-0004](0004-task-results-in-final-tasks.md) | Task Results in Final Tasks | implementable | 2020-11-10 |
 |[TEP-0005](0005-tekton-oci-bundles.md) | Tekton OCI Bundles | implementable | 2020-08-13 |
 |[TEP-0006](0006-tekton-metrics.md) | Tekton Metrics | proposed | 2020-07-13 |


### PR DESCRIPTION
This updates the TEP to in what case the version of the resource
should be updated in the catalog. If there is a field addition with default value
in existing resource and it is not going to change the behavior of resource
and not gonna break existing pipelines then version bump is not required.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

cc @vdemeester @bobcatfish  @vinamra28  @piyush-garg 