### PR TITLE
Add sbwsg as owner on community repo

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,3 +8,4 @@ approvers:
 - abayer
 - ImJasonH
 - afrittoli
+- sbwsg


### PR DESCRIPTION
I'm an owner on the pipelines repo and would like to help out with approvals
on TEPs related to pipelines.

I've contributed a bit to the community repo already with various TEPs and
process-related changes:

- Step & Sidecar Workspaces TEP: https://github.com/tektoncd/community/pull/225
- Optional Workspaces TEP: https://github.com/tektoncd/community/pull/169
- TEP Template updates: https://github.com/tektoncd/community/pull/268, https://github.com/tektoncd/community/pull/270, https://github.com/tektoncd/community/pull/238