### PR TITLE
Update self-reference from master to main 🧙

### DIFF
--- a/design-principles.md
+++ b/design-principles.md
@@ -10,7 +10,7 @@
 1. Tekton should contain only the bare minimum and simplest features needed to meet the largest number of CI/CD use cases.
 1. Prefer a [simple](https://www.infoq.com/presentations/Simple-Made-Easy/) solution that solves most use cases to a complex solution that solves all use cases (can be revisited later).
 1. New features should be consistent with existing components, in structure and behavior, to make learnability, trialability and adoption easy.
-1. Any new feature should have been previously discussed and agreed upon in a [Tekton Enhancement Proposal](https://github.com/tektoncd/community/tree/master/teps). 
+1. Any new feature should have been previously discussed and agreed upon in a [Tekton Enhancement Proposal](https://github.com/tektoncd/community/tree/main/teps). 
 1. In TEPs, demonstrate that the proposed feature is absolutely necessary. What’s the current experience without the feature and how challenging is it?
 
 ## Flexibility
@@ -25,4 +25,4 @@
 ## Conformance
 1. Tekton features should work as the user expects in varied environment setup.
 1. Tekton should not contain kubernetes-specific features, such as configuations for a `Pod`, in the API as much as possible. When kubernetes-specific features have to be added, they should be explicitly called out in the design docs and consider shunting them together into a section of the API, such as `podTemplate`.  
-1. In TEPs, discuss how the proposal affects [conformance](https://github.com/tektoncd/community/blob/master/teps/0012-api-spec.md).
+1. In TEPs, discuss how the proposal affects [conformance](https://github.com/tektoncd/community/blob/main/teps/0012-api-spec.md).

--- a/governance.md
+++ b/governance.md
@@ -70,7 +70,7 @@ activities:
 * The [Tekton Mission and Vision](roadmap.md)
 * Select [election officers](#election-officers) to run elections
 
-It defines the processes around [TEPs](https://github.com/tektoncd/community/tree/master/teps).
+It defines the processes around [TEPs](https://github.com/tektoncd/community/tree/main/teps).
 Should the community fail to reach consensus on whether to accept a proposed
 TEP or not, the governance committee can help to break the impasse.
 

--- a/process.md
+++ b/process.md
@@ -224,12 +224,12 @@ If you have an idea for a project that you'd like to add to `Tekton`,
 you should [be aware of the requirements](#project-requirements) follow this process:
 
 1. Propose the project in
-  [a Tekton working group meeting](https://github.com/tektoncd/community/blob/master/working-groups.md)
+  [a Tekton working group meeting](https://github.com/tektoncd/community/blob/main/working-groups.md)
 2. [File an issue in the `community` repo](https://github.com/tektoncd/community/issues)
   which describes:
     * The problem the project will solve
     * Who will own it
-3. Once [at least 2 governing committee members](https://github.com/tektoncd/community/blob/master/governance.md)
+3. Once [at least 2 governing committee members](https://github.com/tektoncd/community/blob/main/governance.md)
    approve the issue, you can [open a PR to add your project to the experimental repo](#experimental-repo)
    (more likely) or if the governing committee members agree, a new repo will be created for you.
 4. You will then be responsible for making sure the project meets [new project requirements](#project-requirements)
@@ -266,7 +266,7 @@ of the repos (unless requested!).
 ### Experimental repo
 
 Projects can be added to the experimental repo when the
-[governing committee members](https://github.com/tektoncd/community/blob/master/governance.md)
+[governing committee members](https://github.com/tektoncd/community/blob/main/governance.md)
 consider them to be potential candidates to be Tekton top level projects, but would like to
 see more design and discussion around before
 [promoting to offical tekton projects](#promotion-from-experimental-to-top-level-repo).
@@ -278,7 +278,7 @@ project is to iterate on the project in a completely different repo and org, whi
 
 #### Promotion from experimental to top level repo
 
-With approval from [at least 2 governing committee members](https://github.com/tektoncd/community/blob/master/governance.md)
+With approval from [at least 2 governing committee members](https://github.com/tektoncd/community/blob/main/governance.md)
 a project can get its own top level repo in [the `tektoncd` org](https://github.com/tektoncd).
 
 The criteria here is that the governing committee agrees that the project

--- a/standards.md
+++ b/standards.md
@@ -6,9 +6,9 @@ The purpose of this doc is to:
 * Establish a baseline for reviewers so they know at a minimum what to look for
 
 Design: Most designs should be first proposed via an issue and possibly a
-[TEP](https://github.com/tektoncd/community/tree/master/teps#tekton-enhancement-proposals-teps).
+[TEP](https://github.com/tektoncd/community/tree/main/teps#tekton-enhancement-proposals-teps).
 API changes should be evaluated according to
-[Tekton Design Principles](https://github.com/tektoncd/community/blob/master/design-principles.md).
+[Tekton Design Principles](https://github.com/tektoncd/community/blob/main/design-principles.md).
 
 Each Pull Request is expected to meet the following expectations around:
 
@@ -21,7 +21,7 @@ Each Pull Request is expected to meet the following expectations around:
   * [Tests](#tests)
   * [Reconciler/Controller Changes](#reconcilercontroller-changes)
 
-_See also [the Tekton review process](https://github.com/tektoncd/community/blob/master/process.md#reviews)._
+_See also [the Tekton review process](https://github.com/tektoncd/community/blob/main/process.md#reviews)._
 
 ## Pull request description
 

--- a/teps/0001-tekton-enhancement-proposal-process.md
+++ b/teps/0001-tekton-enhancement-proposal-process.md
@@ -59,7 +59,7 @@ following:
 
 into one file which is created incrementally in collaboration with one
 or more [Working
-Groups](https://github.com/tektoncd/community/blob/master/working-groups.md)
+Groups](https://github.com/tektoncd/community/blob/main/working-groups.md)
 (WGs).
 
 This process does not block authors from doing early design docs using
@@ -108,7 +108,7 @@ their adoption strategy.
 
 Before this proposal, there is no a standard way or template to
 create project enhancements, only
-[suggestions](https://github.com/tektoncd/community/blob/master/process.md#proposing-features)
+[suggestions](https://github.com/tektoncd/community/blob/main/process.md#proposing-features)
 on proposing a feature. We rely on documents hosted on Google docs,
 without a standard template explaining the change. Once a proposal is
 done, via a design docs, it tends to be hard to follow what happens
@@ -208,9 +208,9 @@ that would, _most likely_ not require a TEP.
 Project creations *or* project promotion from the experimental project
 would also fall under the TEP process, deprecating the current
 [project
-proposal](https://github.com/tektoncd/community/blob/master/process.md#proposing-projects)
+proposal](https://github.com/tektoncd/community/blob/main/process.md#proposing-projects)
 process (but not the [project
-requirements](https://github.com/tektoncd/community/blob/master/process.md#project-requirements)).
+requirements](https://github.com/tektoncd/community/blob/main/process.md#project-requirements)).
 
 
 ### TEP Template

--- a/teps/0020-s390x-support.md
+++ b/teps/0020-s390x-support.md
@@ -130,7 +130,7 @@ Existing unit and e2e tests will be executed on s390x architecture.
 
 ## References
 
-- [TEP 19 "Other architecture support"](https://github.com/tektoncd/community/blob/master/teps/0019-other-arch-support.md)
+- [TEP 19 "Other architecture support"](https://github.com/tektoncd/community/blob/main/teps/0019-other-arch-support.md)
 - Issue [tektoncd/plumbing#495](https://github.com/tektoncd/plumbing/issues/495)
 - Issue [tektoncd/pipeline#856](https://github.com/tektoncd/pipeline/issues/856)
 - Issue [tektoncd/pipeline#3064](https://github.com/tektoncd/pipeline/issues/3064)

--- a/teps/0024-embedded-trigger-templates.md
+++ b/teps/0024-embedded-trigger-templates.md
@@ -76,7 +76,7 @@ There are two changes proposed to the Trigger spec:
 2. Deprecate the `name` field for reffering to TriggerTemplate objects in favor
    of a new `ref` field. This is for consistency as we use usually use `ref` to
    refer to other resources (see `bindings` as an
-   [example](https://github.com/tektoncd/community/blob/master/teps/0016-concise-trigger-bindings.md#proposal)).
+   [example](https://github.com/tektoncd/community/blob/main/teps/0016-concise-trigger-bindings.md#proposal)).
    Example:
    ```yaml
    # DEPRECATED
@@ -104,4 +104,4 @@ compatible:
 
 1. GitHub issue: https://github.com/tektoncd/triggers/issues/616
 
-1. Embedded Bindings: https://github.com/tektoncd/community/blob/master/teps/0016-concise-trigger-bindings.md
+1. Embedded Bindings: https://github.com/tektoncd/community/blob/main/teps/0016-concise-trigger-bindings.md

--- a/teps/0040-ignore-step-errors.md
+++ b/teps/0040-ignore-step-errors.md
@@ -142,7 +142,7 @@ This proposal is limited to a step within a task and does not address `pipelineT
 * As a new Tekton user, I want to migrate existing scripts and automations from other CI/CD systems that allowed a
   similar step unit of failure.
 
-* A [platform team](https://github.com/tektoncd/community/blob/master/user-profiles.md#1-pipeline-and-task-authors)
+* A [platform team](https://github.com/tektoncd/community/blob/main/user-profiles.md#1-pipeline-and-task-authors)
   wants to share a `Task` with their team which runs the following steps in a sequence:
   * Run unit tests (which may fail)
   * Apply a transformation to the test results (e.g. converts them to a certain format such as junit)

--- a/teps/0045-whenexpressions-in-finally-tasks.md
+++ b/teps/0045-whenexpressions-in-finally-tasks.md
@@ -140,7 +140,7 @@ List the specific goals of the TEP.  What is it trying to achieve?  How will we
 know that this has succeeded?
 -->
 
-- Improve the [reusability](https://github.com/tektoncd/community/blob/master/design-principles.md#reusability)
+- Improve the [reusability](https://github.com/tektoncd/community/blob/main/design-principles.md#reusability)
 of `Tasks` by improving the guarding of `Finally Tasks` at authoring time.
 - Enable guarding execution of `Finally Tasks` using `WhenExpressions`.  
 
@@ -334,14 +334,14 @@ expectations).
 ## Design Evaluation
 <!--
 How does this proposal affect the reusability, simplicity, flexibility 
-and conformance of Tekton, as described in [design principles](https://github.com/tektoncd/community/blob/master/design-principles.md)
+and conformance of Tekton, as described in [design principles](https://github.com/tektoncd/community/blob/main/design-principles.md)
 -->
 
-- [Reusability](https://github.com/tektoncd/community/blob/master/design-principles.md#reusability): This proposal reuses
+- [Reusability](https://github.com/tektoncd/community/blob/main/design-principles.md#reusability): This proposal reuses
   an existing component, `WhenExpressions`, to guard `Finally Tasks`. Moreover, it improves the reusability of `Tasks` by
   enabling specifying guards explicitly and avoiding representing them in the `Tasks`'s `Steps`. 
   
-- [Simplicity](https://github.com/tektoncd/community/blob/master/design-principles.md#simplicity): Using `WhenExpressions`
+- [Simplicity](https://github.com/tektoncd/community/blob/main/design-principles.md#simplicity): Using `WhenExpressions`
   to guard the execution of `Finally Tasks` is much simpler than the workarounds that used `Workspaces`. It is also 
   consistent with how we already guard the other `Tasks`.
   
@@ -368,8 +368,8 @@ information to express the idea and why it was not acceptable.
   However, users creating workarounds to support guarding `Finally Tasks`. In addition, we already [allow skipping](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md#consuming-task-execution-results-in-finally)
   `Finally Tasks` they use uninitialized `Results` from skipped or failed `Tasks`. 
 
-- Use `Conditions` to guard `Finally Tasks`. However, `Conditions` were deprecated and replaced with [`WhenExpressions`](https://github.com/tektoncd/community/blob/master/teps/0007-conditions-beta.md),
-  read further details in [Conditions Beta TEP](https://github.com/tektoncd/community/blob/master/teps/0007-conditions-beta.md).
+- Use `Conditions` to guard `Finally Tasks`. However, `Conditions` were deprecated and replaced with [`WhenExpressions`](https://github.com/tektoncd/community/blob/main/teps/0007-conditions-beta.md),
+  read further details in [Conditions Beta TEP](https://github.com/tektoncd/community/blob/main/teps/0007-conditions-beta.md).
 
 
 ## References
@@ -380,9 +380,9 @@ shared drive, examples, etc. This is useful to refer back to any other related l
 to get more details.
 -->
 
-- [TEP for `WhenExpressions`](https://github.com/tektoncd/community/blob/master/teps/0007-conditions-beta.md)  
+- [TEP for `WhenExpressions`](https://github.com/tektoncd/community/blob/main/teps/0007-conditions-beta.md)  
 - [Guarding `Task` execution using `WhenExpressions`](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md#guard-task-execution-using-whenexpressions)
-- [TEP for `Tasks` `Results` in `Finally Tasks`](https://github.com/tektoncd/community/blob/master/teps/0004-task-results-in-final-tasks.md)
+- [TEP for `Tasks` `Results` in `Finally Tasks`](https://github.com/tektoncd/community/blob/main/teps/0004-task-results-in-final-tasks.md)
 - [Consuming `Tasks` `Results` in `Finally Tasks`](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md#consuming-task-execution-results-in-finally)  
-- [TEP for `Task` execution status in `Finally Tasks`](https://github.com/tektoncd/community/blob/master/teps/0028-task-execution-status-at-runtime.md)
+- [TEP for `Task` execution status in `Finally Tasks`](https://github.com/tektoncd/community/blob/main/teps/0028-task-execution-status-at-runtime.md)
 - [Accessing `Task` execution status in `Finally Tasks`](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md#using-execution-status-of-pipelinetask)

--- a/teps/0051-ppc64le-architecture-support.md
+++ b/teps/0051-ppc64le-architecture-support.md
@@ -110,5 +110,5 @@ Existing unit and e2e tests will be executed on ppc64le architecture.
 
 ## References
 
-- [TEP 19 "Other architecture support"](https://github.com/tektoncd/community/blob/master/teps/0019-other-arch-support.md)
+- [TEP 19 "Other architecture support"](https://github.com/tektoncd/community/blob/main/teps/0019-other-arch-support.md)
 - Issue [tektoncd/pipeline#856](https://github.com/tektoncd/pipeline/issues/856)

--- a/teps/README.md
+++ b/teps/README.md
@@ -34,7 +34,7 @@ following:
 
 into one file which is created incrementally in collaboration with one
 or more [Working
-Groups](https://github.com/tektoncd/community/blob/master/working-groups.md)
+Groups](https://github.com/tektoncd/community/blob/main/working-groups.md)
 (WGs).
 
 This process does not block authors from doing early design docs using

--- a/teps/README.md.mustache
+++ b/teps/README.md.mustache
@@ -34,7 +34,7 @@ following:
 
 into one file which is created incrementally in collaboration with one
 or more [Working
-Groups](https://github.com/tektoncd/community/blob/master/working-groups.md)
+Groups](https://github.com/tektoncd/community/blob/main/working-groups.md)
 (WGs).
 
 This process does not block authors from doing early design docs using


### PR DESCRIPTION
This updates any self reference of community repository to target the
main branch instead of the master branch.

/cc @afrittoli @bobcatfish @ImJasonH @jerop

Re-created https://github.com/tektoncd/community/pull/331 (I messed up the branch 😅 )

Signed-off-by: Vincent Demeester <vincent@sbr.pm>