### PR TITLE
Create a team of doc reviewers

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -680,3 +680,14 @@ orgs:
         privacy: closed
         repos:
           chains: read
+      docs.reviewers:
+        description: Doc reviewers across repos
+        maintainers:
+        - abayer
+        - afrittoli
+        - bobcatfish
+        - dibyom
+        - vdemeester
+        members:
+        - sergetron
+        privacy: closed


### PR DESCRIPTION
The team can be mentioned in PRs where documents are modified
to help keep on top of doc reviews.

https://github.com/tektoncd/website/issues/252

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>