### PR TITLE
Add briangleeson to Dashboard collaborators

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -34,6 +34,7 @@ orgs:
     - barthy1
     - bigkevmcd
     - briandealwis
+    - briangleeson
     - caniszczyk
     - carlos-logro
     - chanseokoh
@@ -457,6 +458,7 @@ orgs:
         - Megan-Wright
         - carlos-logro
         - AlanGreene
+        - briangleeson
         - ncskier
         - CarolynMabbott
         - dibbles


### PR DESCRIPTION
I am part of the team at IBM that works with @AlanGreene on the Dashboard.
Adding to the collaborators team so I can be assigned for reviews etc.

PR open for adding to dashboard reviewers list in 
https://github.com/tektoncd/dashboard/pull/1990