### PR TITLE
Mark 0031 as implemented

### DIFF
--- a/teps/0031-tekton-bundles-cli.md
+++ b/teps/0031-tekton-bundles-cli.md
@@ -3,8 +3,8 @@ title: tekton-bundles-cli
 authors:
   - "@pierretasci"
 creation-date: 2020-11-18
-last-updated: 2020-12-07
-status: implementable
+last-updated: 2021-03-26
+status: implemented
 ---
 # TEP-0031: Tekton Bundles CLI
 
@@ -22,6 +22,7 @@ status: implementable
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Drawbacks](#drawbacks)
 - [Alternatives](#alternatives)
+- [References](#references)
 <!-- /toc -->
 
 ## Summary
@@ -90,15 +91,6 @@ tkn bundle push <REF> [BUNDLE_OBJECT] -f [BUNDLE_OBJECT]
 # Fetches a Tekton Bundle and prints its contents in a configurable format. If KIND is specified, will print only
 # objects of the specified kind (eg, Pipeline or Task). If KIND and NAME are specified, will retrieve a specific object.
 tkn bundle get <REF> [KIND] [NAME] --output=[FORMAT]
-
-# The following are amendments to existing commands.
-
-# Retrieves from an image the requested task(s) rather than from the cluster. Will print the result in the specified
-# format, such as yaml or json.
-tkn task list --image=<REF> --output=[FORMAT]
-tkn task get --image=<REF> --output=[FORMAT] [NAME]
-
-# ... the pipeline command receives these changes as well
 ```
 
 ### Detailed Design
@@ -152,3 +144,7 @@ try out Tekton Bundles.
 2. We could forgo making our own API and just offer specs, examples, and/or documentation for user's to build their own
 APIs. This is a risky prospect because the community might diverge in the way bundles are used and created if there
 isn't at least one official, minimal tool for creating them. It might also hurt the adoption of the feature.
+
+## References
+
+*PRs*: [1](https://github.com/tektoncd/cli/pull/1312) & [2](https://github.com/tektoncd/cli/pull/1328)

--- a/teps/README.md
+++ b/teps/README.md
@@ -161,7 +161,7 @@ This is the complete list of Tekton teps:
 |[TEP-0028](0028-task-execution-status-at-runtime.md) | task-exec-status-at-runtime | implementable | 2020-11-02 |
 |[TEP-0029](0029-step-workspaces.md) | step-and-sidecar-workspaces | implementable | 2020-10-02 |
 |[TEP-0030](0030-workspace-paths.md) | workspace-paths | proposed | 2020-10-18 |
-|[TEP-0031](0031-tekton-bundles-cli.md) | tekton-bundles-cli | implementable | 2020-12-07 |
+|[TEP-0031](0031-tekton-bundles-cli.md) | tekton-bundles-cli | implemented | 2021-03-26 |
 |[TEP-0032](0032-tekton-notifications.md) | Tekton Notifications | proposed | 2020-11-18 |
 |[TEP-0033](0033-tekton-feature-gates.md) | Tekton Feature Gates | proposed | 2020-11-20 |
 |[TEP-0035](0035-document-tekton-position-around-policy-authentication-authorization.md) | document-tekton-position-around-policy-authentication-authorization | implementable | 2020-12-09 |


### PR DESCRIPTION
The principal work for TEP 0031 has now been implemented (`tkn bundle list` and `tkn bundle push`) so mark the TEP as implemented.

The original proposal did call for additional changes that amend behavior of existing `tkn` commands but those were never strongly agreed upon anyways. During implementation it has become clear that `tkn bundle push` and `tkn bundle list` is a "complete" MVP experience and that we should start with just that. We can evolve from here instead of adding additional changes we aren't sure we need.
