### PR TITLE
add jerop and pritidesai to teps/OWNERS

### DIFF
--- a/teps/OWNERS
+++ b/teps/OWNERS
@@ -14,6 +14,7 @@ approvers:
 - houshengbo
 - hrishin
 - iancoffey
+- jerop
 - khrm
 - kimsterv
 - mnuttall
@@ -22,6 +23,7 @@ approvers:
 - piyush-garg
 - pradeepitm12
 - pratap0007
+- pritidesai
 - sbwsg
 - skaegi
 - sm43


### PR DESCRIPTION
@jerop and @pritidesai are owners in Pipelines project -- they need to be added in teps/OWNERS to approve Pipelines TEPs