### PR TITLE
Add Savita as operator maintainer 🧙

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -254,6 +254,7 @@ orgs:
         - sthaha
         - nikhil-thomas
         - vincent-pli
+        - savitaashture
         privacy: closed
         repos:
           operator: write
@@ -626,6 +627,7 @@ orgs:
         - savitaashture
         - vdemeester
         - vincent-pli
+        - piyush-garg
         privacy: closed
         repos:
           operator: read


### PR DESCRIPTION
and Piyush as collaboratior. This follows updates to the `OWNERs` file
in tektoncd/operator.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @afrittoli 