### PR TITLE
Update admins and OWNERS post election 🗳️

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,10 +2,7 @@
 
 approvers:
 - bobcatfish
-- dlorenc
 - vdemeester
-- kimsterv
 - abayer
-- ImJasonH
 - afrittoli
-- sbwsg
+- dibyom

--- a/org/org.yaml
+++ b/org/org.yaml
@@ -6,8 +6,8 @@ orgs:
     - tekton-robot
     - thelinuxfoundation
     - vdemeester
-    - imjasonh
     - afrittoli
+    - dibyom
     billing_email: info@cd.foundation
     company: ''
     default_repository_permission: none


### PR DESCRIPTION
In https://github.com/tektoncd/community/pull/410 I am continuing to try
to make admin/ownership updates after our last election. @dibyom has
joined our governing board so should be added as an admin and owner;
former members should be removed.

Also removed @sbwsg from the top level OWNERS list b/c it looks like he
was added to that to help out with TEP review, and the OWNERS file in
teps/OWNERS should allow him to do this.