### PR TITLE
Adding team members to the org member 😔

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -60,6 +60,7 @@ orgs:
     - houshengbo
     - hrishin
     - iancoffey
+    - ImJasonH
     - ispasov
     - jerop
     - jessm12
@@ -92,6 +93,7 @@ orgs:
     - nikhil-thomas
     - othomann
     - Peaorl
+    - pierretasci
     - piyush-garg
     - popcor255
     - pradeepitm12


### PR DESCRIPTION
Jason and Pierre were added to the org before using peribolos to
maintain the teams and members. For some reason they didn't appear on
the org member list. As they are either in maintainers or
collaborators team, they need to appear as the org member
too. Otherwise, peribolos validation fails and the org.yaml is never
synced with the github teams.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>