### PR TITLE
Remove dibyom from org members… 😅

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -43,7 +43,6 @@ orgs:
     - concaf
     - danielhelfand
     - dibbles
-    - dibyom
     - divyansh42
     - dlorenc
     - dorismeixing


### PR DESCRIPTION
… as he is an admin now, and thus can't be in both.

/cc @afrittoli 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
