### PR TITLE
Remove sergetron from the organization 🧣

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -109,7 +109,6 @@ orgs:
     - sbose78
     - sbwsg
     - sclevine
-    - sergetron
     - shashwathi
     - simonjjones
     - skaegi


### PR DESCRIPTION
The username doesn't exists anymore.

/cc @afrittoli 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>