### PR TITLE
Add sbwsg for lgtm to experimental collaborators

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -509,6 +509,7 @@ orgs:
         - pritidesai
         - jerop
         - bigkevmcd
+        - sbwsg
         privacy: closed
         repos:
           experimental: read


### PR DESCRIPTION
In a [previous PR](https://github.com/tektoncd/experimental/pull/748) I added myself for /approve powers on experimental
and would also like to be able to add lgtms.

This PR adds me to the org.yaml for experimental collaborators so
I can add lgtms on projects in that repo.