### PR TITLE
Update that tekton-users can now have read access to the drive

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -46,5 +46,6 @@ _See [the calendar](#calendar) for more events._
 
 As much as we can we try to add community docs to
 [our shared Google drive](https://drive.google.com/drive/u/0/folders/0AFOvPxM9MpebUk9PVA).
-Anyone who joins [the mailing list](#mailing-list) will be able to add and edit files in this drive,
-which includes design docs and and our [working groups](./working-groups.md) recordings.
+Anyone who joins [the `tekton-dev` mailing list](#mailing-list) will be able to add and edit files in this drive,
+and anyone who joins the [the `tekton-users` mailing list](#mailing-list) will have read access. This drive
+contains docs and our [working groups](./working-groups.md) recordings.


### PR DESCRIPTION
Julian Modesto sent an email to the tekton-users@ mailing list
requesting that this group get read access to the shared tekton drive
which seems reasonable so I've updated the permissions. This PR is
updating the docs to reflect that.