### PR TITLE
TEP-0020: s390x architecture support - Mark as Implemented

### DIFF
--- a/teps/0020-s390x-support.md
+++ b/teps/0020-s390x-support.md
@@ -3,8 +3,8 @@ title: s390x Support
 authors:
   - "@barthy1"
 creation-date: 2020-09-21
-last-updated: 2020-09-21
-status: proposed
+last-updated: 2021-06-04
+status: implemented
 ---
 
 # TEP-0020: s390x architecture support

--- a/teps/README.md
+++ b/teps/README.md
@@ -151,7 +151,7 @@ This is the complete list of Tekton teps:
 |[TEP-0015](0015-pending-pipeline.md) | pending-pipeline-run | implementable | 2020-09-10 |
 |[TEP-0016](0016-concise-trigger-bindings.md) | Concise Embedded TriggerBindings | implemented | 2020-09-15 |
 |[TEP-0019](0019-other-arch-support.md) | Other Arch Support | proposed | 2020-09-30 |
-|[TEP-0020](0020-s390x-support.md) | s390x Support | proposed | 2020-09-21 |
+|[TEP-0020](0020-s390x-support.md) | s390x Support | implemented | 2021-06-04 |
 |[TEP-0021](0021-results-api.md) | Tekton Results API | implementable | 2020-10-26 |
 |[TEP-0022](0022-trigger-immutable-input.md) | Triggers - Immutable Input Events | implementable | 2020-09-29 |
 |[TEP-0024](0024-embedded-trigger-templates.md) | Embedded TriggerTemplates | implemented | 2020-10-01 |


### PR DESCRIPTION
The Tekton releases and tests for `linux/s390x` are running already.
See the s390x nightly tests at [dogfooding cluster](https://dashboard.dogfooding.tekton.dev/#/namespaces/bastion-z/pipelineruns)

/kind tep