### PR TITLE
TEP template update: New section, Implementation pull request(s)

### DIFF
--- a/teps/0002-custom-tasks.md
+++ b/teps/0002-custom-tasks.md
@@ -40,6 +40,8 @@ Original Google Doc proposal, visible to members of tekton-dev@: https://docs.go
   - [Infrastructure Needed (optional)](#infrastructure-needed-optional)
   - [Upgrade &amp; Migration Strategy (optional)](#upgrade--migration-strategy-optional)
 - [Open Questions](#open-questions)
+- [Implementation Pull request(s)](#implementation-pull-request-s)
+
 <!-- /toc -->
 
 ## Summary
@@ -426,3 +428,8 @@ TBD. At this time, the proposal only covers adding new a type and documentating 
 * Versioning and release cadence and ownership of `tektoncd/sample-task` repo; will it be released/versioned alongside `tektoncd/pipeline`?
 
 * Support for "unnamed" Tasks -- i.e., `Run`s that reference an `apiVersion` and `kind`, but not a `name`. A Custom Task author could either use this to provide "default" behavior where a Task CR doesn't need to be defined, or could not define a CRD at all and only support functionality specified by params. Examples of this are `CEL` and `Wait` tasks that just accept a param for `expression` or `duration`, and don't require defining a `CEL` or `Wait` CRD type.
+
+## Implementation Pull request(s)
+
+1. [API Changes, docs and e2e tests](https://github.com/tektoncd/pipeline/pull/3463)
+2. [Do not allow use of deprecated Conditions with custom tasks](https://github.com/tektoncd/pipeline/pull/3601)

--- a/teps/0015-pending-pipeline.md
+++ b/teps/0015-pending-pipeline.md
@@ -4,7 +4,7 @@ authors:
   - "@jbarrick-mesosphere"
 creation-date: 2020-09-10
 last-updated: 2020-09-10
-status: implementable
+status: implemented
 ---
 
 # TEP-0015: Support Pending PipelineRuns
@@ -19,6 +19,8 @@ status: implementable
   - [User Stories](#user-stories)
     - [Platform Implementor](#platform-implementor)
 - [Alternatives](#alternatives)
+- [Implementation Pull request(s)](#implementation-pull-request-s)
+
 <!-- /toc -->
 
 ## Summary
@@ -116,3 +118,7 @@ able to run without introducing bespoke machinery.
   non-Kubernetes-native queue, such as Redis, and only submitted once they are
   ready to run. This adds complexity in that a new data store must be run and
   it is not easy to provide users visibility into the queue.
+
+## Implementation Pull request(s)
+
+1. [API Changes, docs and e2e tests](https://github.com/tektoncd/pipeline/pull/3522)

--- a/teps/0061-allow-custom-task-to-be-embedded-in-pipeline.md
+++ b/teps/0061-allow-custom-task-to-be-embedded-in-pipeline.md
@@ -30,6 +30,7 @@ authors:
 - [Alternatives](#alternatives)
 - [Infrastructure Needed (optional)](#infrastructure-needed-optional)
 - [Upgrade &amp; Migration Strategy (optional)](#upgrade--migration-strategy-optional)
+- [Implementation Pull request(s)](#implementation-pull-request-s)
 - [References (optional)](#references-optional)
 <!-- /toc -->
 
@@ -483,6 +484,12 @@ behavior or add a feature that may replace and deprecate a current one.
     TODO: Add a reference to an example custom task controller e.g. `TaskLoop`, once
     the changes are merged.
   
+## Implementation Pull request(s)
+
+1. [API Changes, docs and e2e tests](https://github.com/tektoncd/pipeline/pull/3901)
+2. [Followup fix](https://github.com/tektoncd/pipeline/pull/3977)
+3. [Followup fix 2](https://github.com/tektoncd/pipeline/pull/4005)
+
 ## References (optional)
 
 <!--

--- a/teps/README.md
+++ b/teps/README.md
@@ -148,7 +148,7 @@ This is the complete list of Tekton teps:
 |[TEP-0011](0011-redirecting-step-output-streams.md) | redirecting-step-output-streams | implementable | 2020-11-02 |
 |[TEP-0012](0012-api-spec.md) | API Specification | implementable | 2020-08-10 |
 |[TEP-0014](0014-step-timeout.md) | Step Timeout | implementable | 2020-09-10 |
-|[TEP-0015](0015-pending-pipeline.md) | pending-pipeline-run | implementable | 2020-09-10 |
+|[TEP-0015](0015-pending-pipeline.md) | pending-pipeline-run | implemented | 2020-09-10 |
 |[TEP-0016](0016-concise-trigger-bindings.md) | Concise Embedded TriggerBindings | implemented | 2020-09-15 |
 |[TEP-0019](0019-other-arch-support.md) | Other Arch Support | proposed | 2020-09-30 |
 |[TEP-0020](0020-s390x-support.md) | s390x Support | proposed | 2020-09-21 |

--- a/teps/tools/tep-template.md.template
+++ b/teps/tools/tep-template.md.template
@@ -73,6 +73,7 @@ tags, and then generate with `hack/update-toc.sh`.
 - [Alternatives](#alternatives)
 - [Infrastructure Needed (optional)](#infrastructure-needed-optional)
 - [Upgrade &amp; Migration Strategy (optional)](#upgrade--migration-strategy-optional)
+- [Implementation Pull request(s)](#implementation-pull-request-s)
 - [References (optional)](#references-optional)
 <!-- /toc -->
 
@@ -260,6 +261,15 @@ SIG to get the process for these resources started right away.
 Use this section to detail wether this feature needs an upgrade or
 migration strategy. This is especially useful when we modify a
 behavior or add a feature that may replace and deprecate a current one.
+-->
+
+## Implementation Pull request(s)
+
+<!--
+Once the TEP is ready to be marked as implemented, list down all the Github
+Pull-request(s) merged.
+Note: This section is exclusively for merged pull requests, for this TEP.
+It will be a quick reference for those looking for implementation of this TEP.
 -->
 
 ## References (optional)


### PR DESCRIPTION
Proposing a new section i.e. `Implementation pull request(s)` to TEP template and updated the same for some of the TEPs.

This section is intended to be filled when the TEP is ready to be marked as implemented or even as a TEP make progress towards being marked implemented.

This was discussed in API WG meeting on June, 7th of 2021 10AM PT.

/cc @afrittoli, @vdemeester 