### PR TITLE
proposal for TEP 0040 - ignore step error with a new section `exit`

### DIFF
--- a/teps/0040-ignore-step-errors.md
+++ b/teps/0040-ignore-step-errors.md
@@ -1,8 +1,8 @@
 ---
-status: proposed
+status: implementable
 title: 'Ignore Step Errors'
 creation-date: '2021-01-06'
-last-updated: '2021-02-04'
+last-updated: '2021-07-09'
 authors:
 - '@pritidesai'
 - '@afrittoli'
@@ -18,6 +18,17 @@ authors:
   - [Non-Goals](#non-goals)
 - [Requirements](#requirements)
   - [Use Cases](#use-cases)
+- [Proposal](#proposal)
+    - [produce a task result with the failed step](#produce-a-task-result-with-the-failed-step)
+  - [Demo](#demo)
+  - [Advantages](#advantages)
+    - [Single Source of Truth](#single-source-of-truth)
+- [Alternatives](#alternatives)
+  - [A <code>bool</code> flag](#a-bool-flag)
+  - [exitCode set to 0 through 255](#exitcode-set-to-0-through-255)
+- [Future Work](#future-work)
+    - [Step exit code as a task result](#step-exit-code-as-a-task-result)
+    - [Additional Use Cases](#additional-use-cases)
 - [References](#references)
 <!-- /toc -->
 
@@ -25,7 +36,7 @@ authors:
 
 Tekton tasks are defined as a collection of steps in which each step can specify a container image to run.
 Steps are executed in order in which they are specified. One single step failure results in a task failure
-i.e. once a step results in a failure, rest of the steps are not executed. When a container exits with
+i.e., once a step results in a failure, rest of the steps are not executed. When a container exits with
 non-zero exit code, the step results in error:
 
 ```yaml
@@ -48,7 +59,7 @@ $ kubectl get tr failing-taskrun-hw5xj -o json | jq .status.steps
 
 `TaskRun` with such step error, stops executing subsequent steps and results in a failure:
 
-```yaml
+```
 $ kubectl get tr failing-taskrun-hw5xj -o json | jq .status.conditions
 [
   {
@@ -145,8 +156,285 @@ This proposal is limited to a step within a task and does not address `pipelineT
 * A [platform team](https://github.com/tektoncd/community/blob/main/user-profiles.md#1-pipeline-and-task-authors)
   wants to share a `Task` with their team which runs the following steps in a sequence:
   * Run unit tests (which may fail)
-  * Apply a transformation to the test results (e.g. converts them to a certain format such as junit)
+  * Apply a transformation to the test results (e.g., converts them to a certain format such as junit)
   * Upload the results to a central location used by all the teams
+
+## Proposal
+
+Introduce a new field `onError` as part of the
+[steps](https://github.com/tektoncd/pipeline/docs/tasks.md#defining-steps) definition along with an `image` and `script`.
+
+```
+- name: failing-step
+  image: alpine
+  onError: [ continue | fail]
+```
+
+The `Step` struct will have a new field `Exit`:
+
+```go
+type Step struct {
+
+    corev1.Container `json:",inline"`
+
+    // Script is the contents of an executable file to execute.
+    Script string `json:"script,omitempty"`
+
+    // ...
+
+    // define the exiting behavior of the container in this field
+    // set onError to fail to indicate the entrypoint to exit the taskRun if the container exits with non zero exit code
+    // set onError to continue to indicate the entrypoint to continue executing the rest of the steps irrespective of the container exit code
+    OnError string `json:"onError,omitempty"`
+}
+```
+
+A `task` author or a `pipeline` author can use `onError` to ignore the step error. If `onError` is
+set to `continue`, the entrypoint sets the original failed exit code of the `script` or the wrapped command in the
+container termination state.
+
+To ignore a step error, set the `onError` to `continue`:
+
+```yaml
+steps:
+  - image: docker.io/library/golang:latest
+    name: ignore-unit-test-failure
+    onError: continue
+    script: |
+      go test .
+```
+
+A `step` with `onError` set to `continue` does not fail the `taskRun` and continues executing the rest of the steps in
+a task. The original failed exit code of the wrapped command is available in the termination state of the container.
+
+```
+kubectl get tr taskrun-unit-test-t6qcl -o json | jq .status
+{
+  "completionTime": "2021-06-21T18:22:06Z",
+  "conditions": [
+    {
+      "lastTransitionTime": "2021-06-21T18:22:06Z",
+      "message": "All Steps have completed executing",
+      "reason": "Succeeded",
+      "status": "True",
+      "type": "Succeeded"
+    }
+  ],
+  "podName": "taskrun-unit-test-t6qcl-pod-zpqs9",
+  "startTime": "2021-06-21T18:21:57Z",
+  "steps": [
+    {
+      "container": "step-ignore-unit-test-failure",
+      "imageID": "...",
+      "name": "ignore-unit-test-failure",
+      "terminated": {
+        "containerID": "...",
+        "exitCode": 1,
+        "finishedAt": "2021-06-21T18:22:05Z",
+        "reason": "Completed",
+        "startedAt": "2021-06-21T18:22:05Z"
+      }
+    },
+  ],
+```
+
+As part of this design, we are introducing an additional internal volume `/tekton/steps/`. A file named `exitCode` will
+be created for each step to store the non-zero exit code, for example:
+
+```
+/tekton/steps/<step-name>/exitCode
+```
+
+`<step-name>` will be replaced with the name of the step. If a step does not have any name, `<step-name>` will be
+replaced with `step-unnamed-<step-index>` where `<step-index>` is `0` for the first step, `1` for the second step, so
+on and so forth.
+
+This new internal volume `/tekton/steps/<step-name>/` can be utilized in future to collect any metadata for each step.
+And instead of referencing to it with the `<step-name>`, will create a symlink such that it can be accessed using the
+`<step-index>`.
+
+```shell
+ln -s /tekton/steps/<step-name> /tekton/steps/<step-index>
+```
+
+Any subsequent step can access the non-zero exit code of a previous step using the `path` similar to a task result,
+for example:
+
+```shell
+$(steps.<step-name>.exitCode.path)
+```
+
+The `exitCode` of a step without any name can be referenced using:
+
+```shell
+$(steps.step-unnamed-<step-index>.exitCode.path)
+```
+
+If you would like to use the tekton internal path, you can access the exit code by reading the file
+(it is not recommended though):
+
+```shell
+cat /tekton/steps/<step-name>/exitCode
+```
+
+#### produce a task result with the failed step
+
+In the following example, the `pipelineRun` is executing two tasks. The first task is producing a result which is being
+consumed by the second task. The first task has a step which can fail and therefore it is defined to
+ignore an error of that step. The same step is producing a task result `task1-result`. If that step is able to initialize
+a result file before failing, that task result is made available to the second task (it's consuming task).
+
+```
+kubectl get pr pipelinerun-with-failing-step-mdncp -o json | jq .status.taskRuns | jq 'map(.status)'
+[
+  {
+    "completionTime": "2021-06-21T18:47:40Z",
+    "conditions": [
+      {
+        "lastTransitionTime": "2021-06-21T18:47:40Z",
+        "message": "All Steps have completed executing",
+        "reason": "Succeeded",
+        "status": "True",
+        "type": "Succeeded"
+      }
+    ],
+    "podName": "pipelinerun-with-failing-step-mdncp-task1-7gvl5-pod-dz5hb",
+    "startTime": "2021-06-21T18:47:32Z",
+    "steps": [
+      {
+        "container": "step-write-a-result",
+        "imageID": "...",
+        "name": "write-a-result",
+        "terminated": {
+          "containerID": "...",
+          "exitCode": 11,
+          "finishedAt": "2021-06-21T18:47:39Z",
+          "message": "[{\"key\":\"task1-result\",\"value\":\"123\",\"type\":\"TaskRunResult\"}]",
+          "reason": "Completed",
+          "startedAt": "2021-06-21T18:47:39Z"
+        }
+      }
+    ],
+    "taskResults": [
+      {
+        "name": "task1-result",
+        "value": "123"
+      }
+    ],
+    ...
+  },
+  {
+    "completionTime": "2021-06-21T18:47:49Z",
+    "conditions": [
+      {
+        "lastTransitionTime": "2021-06-21T18:47:49Z",
+        "message": "All Steps have completed executing",
+        "reason": "Succeeded",
+        "status": "True",
+        "type": "Succeeded"
+      }
+    ],
+    "podName": "pipelinerun-with-failing-step-mdncp-task2-9w7cj-pod-sw6sw",
+    "startTime": "2021-06-21T18:47:40Z",
+    "steps": [
+      {
+        "container": "step-verify-a-task-result",
+        "imageID": "...",
+        "name": "verify-a-task-result",
+        "terminated": {
+          "containerID": "...",
+          "exitCode": 0,
+          "finishedAt": "2021-06-21T18:47:49Z",
+          "reason": "Completed",
+          "startedAt": "2021-06-21T18:47:49Z"
+        }
+      }
+    ],
+    ...
+  }
+]
+```
+
+This new field `exit` will be implemented as a `alpha` feature and can be enabled by setting `enable-api-fields`
+to `alpha`.
+
+### Demo
+
+This proposal was demonstrated in API WG on 6/21/2021.
+A screen recording is also available [here](https://youtu.be/eUFpk2sBuC4).
+
+### Advantages
+
+#### Single Source of Truth
+
+  This is a very clean design in which the original failed exit code is part of the terminated state. There is no
+  separate placeholder needed for the failed exit code. There is no special logic needed to access the failed exit code.
+  `exitCode` in the terminated state of the container can hold both zero/non-zero exit code. The dashboard team
+  can highlight this kind of step if the container terminated with a non-zero `exitCode`.
+
+## Alternatives
+
+### A `bool` flag
+
+Instead of introducing a new section, introduce a new `bool` flag such as either `captureExitCode` or
+`ignoreStepError`. By default, it will be set to `false`. Set it to `true` to ignore the step error.
+
+### exitCode set to 0 through 255
+
+  This provides an option to a `task` author or a `pipeline` author to overwrite the original exit code with their
+  desired value. At the same time, it provides an option to continue treating that step as a failure since the step
+  exiting with any non-zero is considered a failure. This option implicitly supports changing the exit code:
+
+  * `exitCode` to `0`: terminate the container with `0` i.e., ignore step error
+  * `exitCode` to `1` - `255`: terminate the container with the specified value i.e., change the exit code
+
+## Future Work
+
+#### Step exit code as a task result
+
+The volume mount `/tekton/steps` is available to all the containers in a pod but not outside that pod i.e. a step exit
+code is not accessible to any other task. To access a step exit code of any task from any other task, a task author
+can introduce an additional step to write it as a task result.
+
+```shell
+ - image: ubuntu
+    name: write-exit-code-result
+    script: |
+      cat /tekton/steps/0/exitCode > $(results.someStepExitCode.path)
+```
+
+Instead of asking a task author to create a task result in this way, we could create a task result for every non-zero
+exit code by design.
+
+#### Additional Use Cases
+
+We have identified a few potential use cases in addition to ignoring a step error.
+
+* Force a step error: I want a process to fail in the step and don't really care about the exit code. If needed, this
+  can be designed by introducing a new field `forceExit`:
+
+  ```go
+    onError:  [ continue | fail ]
+    forceExit: [ true | false ]
+  ```
+
+* Change the exit code of a step:
+
+  If linting exits with any non-zero exit code
+  * Prod: exit with 1 in prod
+  * Dev: ignore non-zero exit code and continue executing the rest of the pipeline.
+
+  This can be achieved by introducing a new field under `exit`.
+
+  ```go
+    exitCode:  [ 0 - 255 | DoNotChange ]
+    onExit:  [ continue | fail ]
+    forceExit: [ true | false ]
+  ```
+
+These additional fields can be grouped in a single section `exit` if needed. We can add `onError` field under this new
+section i.e. we can support both specifying `onError` at the step specification level and under `exit` section. The
+decision to add such section can be delayed until we have a use case.
 
 
 ## References
@@ -155,3 +443,7 @@ This proposal is limited to a step within a task and does not address `pipelineT
 * [Add a field to Step that allows it to ignore failed prior Steps *within the same Task, tektoncd/pipeline#1559](https://github.com/tektoncd/pipeline/issues/1559)
 * [Scott's Changes to allow steps to run regardless of previous step errors](https://github.com/tektoncd/pipeline/pull/1573)
 * [Christie's Notes](https://docs.google.com/document/d/11wygsRe2d4G-wTJMddIdBgSOB5TpsWCqGGACSXusy_U/edit?resourcekey=0-skOAYQiz0xIktxYxCm-SFg) - Thank You, Christie!
+* [Andrea's PoC](https://github.com/tektoncd/pipeline/compare/main...afrittoli:tep_0040)
+* [PR Review Discussion](https://docs.google.com/document/d/1KGmyiMPzFq2mwKLtwac5VtgpAs0GlPo5RDb8MqY-uuw/edit?usp=sharing)
+* [Priti's PoC](https://github.com/tektoncd/pipeline/compare/main...pritidesai:tep-0040?expand=1)
+* [Demo](https://youtu.be/eUFpk2sBuC4)

--- a/teps/README.md
+++ b/teps/README.md
@@ -192,7 +192,7 @@ This is the complete list of Tekton teps:
 |[TEP-0037](0037-remove-gcs-fetcher.md) | Remove `gcs-fetcher` image | implementing | 2021-01-27 |
 |[TEP-0038](0038-generic-workspaces.md) | Generic Workspaces | proposed | 2020-12-11 |
 |[TEP-0039](0039-add-variable-retries-and-retrycount.md) | Add Variable `retries` and `retry-count` | proposed | 2021-01-31 |
-|[TEP-0040](0040-ignore-step-errors.md) | Ignore Step Errors | proposed | 2021-02-04 |
+|[TEP-0040](0040-ignore-step-errors.md) | Ignore Step Errors | implementable | 2021-07-09 |
 |[TEP-0041](0041-tekton-component-versioning.md) | Tekton Component Versioning | implementable | 2021-04-26 |
 |[TEP-0042](0042-taskrun-breakpoint-on-failure.md) | taskrun-breakpoint-on-failure | proposed | 2021-03-21 |
 |[TEP-0044](0044-decouple-task-composition-from-scheduling.md) | Decouple Task Composition from Scheduling | proposed | 2021-03-10 |


### PR DESCRIPTION
Introduce a new field `onError` while defining a step to indicate to ignore the error:

```yaml
onError:  [ continue | fail ]
```

For example,

```yaml
steps:
  - image: docker.io/library/golang:latest
    name: ignore-unit-test-failure
    onError: continue
    script: |
      go test .
```

The original failed exit code will be part of the run status:

```json
 "steps": [
    {
      "container": "step-ignore-unit-test-failure",
      "imageID": "...",
      "name": "ignore-unit-test-failure",
      "terminated": {
        "containerID": "...",
        "exitCode": 1,
        "finishedAt": "2021-06-21T18:22:05Z",
        "reason": "Completed",
        "startedAt": "2021-06-21T18:22:05Z"
      }
    },
  ],
```

And will be available at `/tekton/steps/0/exitCode`.


Design iterations:

Iteration 1:

```yaml
exit:
        continue:  [ afterSuccess | always ]
```

For example,

```yaml
steps:
  - image: docker.io/library/golang:latest
    name: ignore-unit-test-failure
    exit:
      continue: always
    script: |
      go test .
```

Iteration 2:

```yaml
exit:
        onError:  [ continue | fail ]
```

For example,

```yaml
steps:
  - image: docker.io/library/golang:latest
    name: ignore-unit-test-failure
    exit:
      onError: continue
    script: |
      go test .
```

/kind tep
