### PR TITLE
Add briangleeson to the dashboard.maintainers team

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -206,12 +206,8 @@ orgs:
         - skaegi
         members:
         - AlanGreene
-        - mnuttall
-        - a-roberts
-        - dibbles
-        - eddycharly
+        - briangleeson
         - steveodonovan
-        - carolynmabbott
         privacy: closed
         repos:
           dashboard: write


### PR DESCRIPTION
Update the dashboard.maintainers team to add briangleeson, he has
already been added as an approver in the OWNERS file in tektoncd/dashboard.
See https://github.com/tektoncd/dashboard/pull/2099

Remove other members from the maintainers team who are no longer involved
with the project, this reflects the current list in the OWNERS file.