### PR TITLE
Add sm43 as collaborator on operator

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -625,14 +625,15 @@ orgs:
         - afrittoli
         - bobcatfish
         - ImJasonH
+        - vdemeester
         members:
         - houshengbo
         - nikhil-thomas
         - pradeepitm12
         - savitaashture
-        - vdemeester
         - vincent-pli
         - piyush-garg
+        - sm43
         privacy: closed
         repos:
           operator: read


### PR DESCRIPTION
Following it's addition to reviewers on the operator repository,
adding him here.

See https://github.com/tektoncd/operator/pull/348

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>