### PR TITLE
Update CLI maintainers 👻

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -172,7 +172,6 @@ orgs:
         description: the cli maintainers
         maintainers:
         - vdemeester
-        - bobcatfish
         members:
         - chmouel
         - sthaha
@@ -539,7 +538,6 @@ orgs:
         description: The cli collaborators
         maintainers:
         - abayer
-        - bobcatfish
         - ImJasonH
         members:
         - Divyansh42

--- a/org/org.yaml
+++ b/org/org.yaml
@@ -172,6 +172,7 @@ orgs:
         description: the cli maintainers
         maintainers:
         - vdemeester
+        - chmouel
         members:
         - chmouel
         - sthaha
@@ -537,8 +538,8 @@ orgs:
       cli.collaborators:
         description: The cli collaborators
         maintainers:
-        - abayer
-        - ImJasonH
+        - chmouel
+        - vdemeester
         members:
         - Divyansh42
         - pradeepitm12


### PR DESCRIPTION
I noticed I had been added as a reviewer to a CLI PR, and it was b/c I'm
in CLI maintainers. However I don't work on the CLI so I don't think I'm
in a good position to be reviewing PRs there, and so I'm removing myself
from the list. That leaves only @vdemeester as a CLI maintainer tho so I
can stay on the list if we wanted to make sure there was more than 1
person, just let me know.