### PR TITLE
TEP-0059: Skipping Strategies - Migration Plan

### DIFF
--- a/teps/0059-skipping-strategies.md
+++ b/teps/0059-skipping-strategies.md
@@ -2,7 +2,7 @@
 status: implementable 
 title: Skipping Strategies 
 creation-date: '2021-03-24' 
-last-updated: '2021-05-06' 
+last-updated: '2021-07-28'
 authors:
 - '@jerop'
 ---
@@ -568,12 +568,15 @@ behavior or add a feature that may replace and deprecate a current one.
 
 Changing the scope of `WhenExpressions` to guard the `Task` only is backwards-incompatible, so to make the 
 transition smooth:
-- we'll provide a feature flag, `set-when-expressions-scope-to-task`, which:
-  - will default to `set-when-expressions-scope-to-task` : `false` to guard a `Task` and its dependent `Tasks`
-  - can be set to `set-when-expressions-scope-to-task` : `true` to guard a `Task` only 
-- after 9 months, we'll flip the feature flag and default to `set-when-expressions-scope-to-task` : `true`
-- after 9 more months, we'll remove the feature flag and `WhenExpressions` will be scoped to guard a `Task` only going 
-  forward
+- we'll provide a feature flag, `scope-when-expressions-to-task`, which:
+  - will default to `scope-when-expressions-to-task` : "false" to guard a `Task` and its dependent `Tasks`
+  - can be set to `scope-when-expressions-to-task` : "true" to guard a `Task` only 
+- after 9 months, per the [Tekton API compatibility policy](https://github.com/tektoncd/pipeline/blob/main/api_compatibility_policy.md#alpha-beta-and-ga), 
+  we'll flip the feature flag and default to `scope-when-expressions-to-task` : `true` [February 2022]
+- in the next release, we'll remove the feature flag and `WhenExpressions` will be scoped to guard a 
+  `Task` only going forward [March 2022]
+- when we do [v1 release](https://github.com/tektoncd/pipeline/issues/3548) (projected for early 2022), we will have 
+`when` expressions guarding a `Task` only both in _beta_ and _v1_
 
 We will over-communicate during the migration in Slack, email and working group meetings. 
 

--- a/teps/README.md
+++ b/teps/README.md
@@ -208,7 +208,7 @@ This is the complete list of Tekton teps:
 |[TEP-0056](0056-pipelines-in-pipelines.md) | Pipelines in Pipelines | proposed | 2021-03-08 |
 |[TEP-0057](0057-windows-support.md) | Windows support | proposed | 2021-03-18 |
 |[TEP-0058](0058-graceful-pipeline-run-termination.md) | Graceful Pipeline Run Termination | implementable | 2021-04-27 |
-|[TEP-0059](0059-skipping-strategies.md) | Skipping Strategies | implementable | 2021-05-06 |
+|[TEP-0059](0059-skipping-strategies.md) | Skipping Strategies | implementable | 2021-07-28 |
 |[TEP-0060](0060-remote-resource-resolution.md) | Remote Resource Resolution | proposed | 2021-06-15 |
 |[TEP-0061](0061-allow-custom-task-to-be-embedded-in-pipeline.md) | Allow custom task to be embedded in pipeline | implemented | 2021-05-26 |
 |[TEP-0062](0062-catalog-tags-and-hub-categories-management.md) | Catalog Tags and Hub Categories Management | implementable | 2021-03-30 |


### PR DESCRIPTION
This change is a clarification and update to the migration and upgrade
plan for skipping strategies.

The implementable proposal is to change the scope of `when` expressions
to guard the `Task`. This is a backwards-incompatible change. To make the
transition smooth, we plan to:
- provide a feature flag, `scope-when-expressions-to-task`, which:
  - will default to `scope-when-expressions-to-task` : "false" to guard
  a `Task` and its dependent `Tasks`
  - can be set to `scope-when-expressions-to-task` : "true" to guard a
  `Task` only
- after 9 months, per the [Tekton API compatibility policy](https://github.com/tektoncd/pipeline/blob/main/api_compatibility_policy.md#alpha-beta-and-ga),
  we'll flip the feature flag and default to `
  scope-when-expressions-to-task` : "true" [February 2022]
- in the next release, we'll remove the feature flag and `when` expressions
 will be scoped to guard a `Task` only going forward [March 2022]
- when we do [v1 release](https://github.com/tektoncd/pipeline/issues/3548)
(projected for early 2022), we will have `when` expressions guarding a
`Task` only both in _beta_ and _v1_

We also plan to over-communicate during the migration in Slack, email
and working group meetings.

/cc @tektoncd/core-maintainers 
/kind tep