### PR TITLE
org: remove duplicated names from cli.maintainers

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -175,7 +175,6 @@ orgs:
         - vdemeester
         - chmouel
         members:
-        - chmouel
         - sthaha
         - piyush-garg
         - hrishin


### PR DESCRIPTION
I missed that one in the previous commit 🤦

/cc @afrittoli @nikhil-thomas 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>