### PR TITLE
Use `stopAndFail` instead of `fail` with `onError` 🧐

### DIFF
--- a/teps/0040-ignore-step-errors.md
+++ b/teps/0040-ignore-step-errors.md
@@ -167,7 +167,7 @@ Introduce a new field `onError` as part of the
 ```
 - name: failing-step
   image: alpine
-  onError: [ continue | fail]
+  onError: [ continue | stopAndFail]
 ```
 
 The `Step` struct will have a new field `Exit`:
@@ -183,7 +183,7 @@ type Step struct {
     // ...
 
     // define the exiting behavior of the container in this field
-    // set onError to fail to indicate the entrypoint to exit the taskRun if the container exits with non zero exit code
+    // set onError to stopAndFail to indicate the entrypoint to exit the taskRun if the container exits with non zero exit code
     // set onError to continue to indicate the entrypoint to continue executing the rest of the steps irrespective of the container exit code
     OnError string `json:"onError,omitempty"`
 }
@@ -414,7 +414,7 @@ We have identified a few potential use cases in addition to ignoring a step erro
   can be designed by introducing a new field `forceExit`:
 
   ```go
-    onError:  [ continue | fail ]
+    onError:  [ continue | stopAndFail ]
     forceExit: [ true | false ]
   ```
 
@@ -428,7 +428,7 @@ We have identified a few potential use cases in addition to ignoring a step erro
 
   ```go
     exitCode:  [ 0 - 255 | DoNotChange ]
-    onExit:  [ continue | fail ]
+    onExit:  [ continue | stopAndFail ]
     forceExit: [ true | false ]
   ```
 


### PR DESCRIPTION
This commit proposes changing the wording of the `fail` option for
`onError` from `fail` to make it more explicitly clear that this option
(which is the default behavior when `onError` is not specified) will
both cause the Task to fail AND stop execution of any subsequent steps.

This change doesn't propose changing any of the described functionality,
just the value of the field.

PTAL @pritidesai @vdemeester  ( @afrittoli I think you're on holiday right now, given this is such a minor change I'm assuming you will be okay with it but strong apologies if not!! 🙏  )