### PR TITLE
TEP-0056: Pipelines in Pipelines - Add Use Case

### DIFF
--- a/teps/README.md
+++ b/teps/README.md
@@ -206,7 +206,7 @@ This is the complete list of Tekton teps:
 |[TEP-0051](0051-ppc64le-architecture-support.md) | ppc64le Support | proposed | 2021-01-28 |
 |[TEP-0052](0052-tekton-results-automated-run-resource-cleanup.md) | Tekton Results: Automated Run Resource Cleanup | implementable | 2021-03-22 |
 |[TEP-0053](0053-nested-triggers.md) | Nested Triggers | implementable | 2021-04-15 |
-|[TEP-0056](0056-pipelines-in-pipelines.md) | Pipelines in Pipelines | proposed | 2021-03-08 |
+|[TEP-0056](0056-pipelines-in-pipelines.md) | Pipelines in Pipelines | proposed | 2021-08-16 |
 |[TEP-0057](0057-windows-support.md) | Windows support | proposed | 2021-03-18 |
 |[TEP-0058](0058-graceful-pipeline-run-termination.md) | Graceful Pipeline Run Termination | implementable | 2021-04-27 |
 |[TEP-0059](0059-skipping-strategies.md) | Skipping Strategies | implementable | 2021-05-06 |


### PR DESCRIPTION
In https://github.com/tektoncd/pipeline/issues/4067, @mjgkaastrupandersen shares an additional use case for pipelines in pipelines. In the issue, they describe how they need a gateway task or grouping of pipelines to simplify specifying that a set of tasks all need to wait for another set of tasks to complete execution. In this change, we add that use case to [TEP-0056: Pipelines in Pipelines](https://github.com/tektoncd/community/blob/main/teps/0056-pipelines-in-pipelines.md).

Thank you for sharing your use case @mjgkaastrupandersen! 😀 

/kind tep