### PR TITLE
Fix link to chains calendar event 📅

### DIFF
--- a/working-groups.md
+++ b/working-groups.md
@@ -305,7 +305,7 @@ This is the working group for [`tektoncd/chains`](https://github.com/tektoncd/ch
 | -------------------------- | -------------------------- |
 | Forum                      | [tekton-dev@](https://groups.google.com/forum/#!forum/tekton-dev) |
 | Community Meeting VC       | [https://meet.google.com/iuv-jbov-fmi](https://meet.google.com/iuv-jbov-fmi) |
-| Community Meeting Calendar | Thursdays every other week, 9am -9:30am PST <br>[Calendar](https://calendar.google.com/calendar/u/0/r/eventedit/copy/Nzc3N2VjZjk3amZnZzc5MDQwODYxNzRrZHVfMjAyMTA2MTBUMTYwMDAwWiBnb29nbGUuY29tX2Qzb3Zjdm8xcDMyMTloOTg5NTczdjk4Zm5zQGc/cHJpeWF3YWRod2FAZ29vZ2xlLmNvbQ?scp=ALL) |
+| Community Meeting Calendar | Thursdays every other week, 9am -9:30am PST <br>[Calendar](https://calendar.google.com/event?action=TEMPLATE&tmeid=Nzc3N2VjZjk3amZnZzc5MDQwODYxNzRrZHVfMjAyMTA4MTlUMTYwMDAwWiBnb29nbGUuY29tX2Qzb3Zjdm8xcDMyMTloOTg5NTczdjk4Zm5zQGc&tmsrc=google.com_d3ovcvo1p3219h989573v98fns%40group.calendar.google.com&scp=ALL) |
 | Meeting Notes              | [Notes](https://docs.google.com/document/d/1UVPSCDyNO-TzEFSv8jrqrEOF_FmV8NFuXncFm1gwmeY/edit) |
 | Slack Channels             | [#chains](https://tektoncd.slack.com/messages/chains) |
 


### PR DESCRIPTION
In the slack #chains channel Naveen Srinivasan pointed out that the
calendar link didn't work - replacing the link with one that does work
(which I got by going to the tekton calendar event and clicking "publish
event")