### PR TITLE
adding pritidesai as chains collaborator

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -690,6 +690,7 @@ orgs:
         - ImJasonH
         - vdemeester
         members:
+        - pritidesai
         - dlorenc
         privacy: closed
         repos:


### PR DESCRIPTION
Adding pritidesai as Chains collaborator to get `lgtm` access on PRs.