### PR TITLE
Adding an hacktoberfest 2021 page

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is the central home for documentation on joining and contributing to the Te
 * [our shared document drive](contact.md#shared-drive)
 * [our shared calendar](contact.md#calendar)
 
-For October 2020: check out our [Hacktoberfest](./hacktoberfest-2020.md) ideas!
+For October 2021: check out our [Hacktoberfest](./hacktoberfest-2021.md) ideas!
 
 See our standards regarding:
 

--- a/hacktoberfest-2021.md
+++ b/hacktoberfest-2021.md
@@ -1,0 +1,47 @@
+## Hacktoberfest 2021 and Tekton!
+
+### What's this about?
+
+We'd love to encourage folks to contribute to Tekton - and over at the [Continuous Delivery Foundation](https://cd.foundation/) we've decided something like this could come in handy.
+
+### Guidance for project maintainers
+
+When creating a new issue for Hacktoberfest, please assign it the hacktoberfest-accepted label and make sure you provide at least:
+
+- A perceived difficulty level
+- Awesome contacts/mentors willing to help out
+- An idea of what we'd like to achieve
+- Any useful pointers for getting started
+
+### Guidance for contributors
+
+The below links all contain the label selector for hacktoberfest-accepted and there you can find all of the issues that the maintainers think would be good ones to get involved in.
+
+We enourage all of the following:
+- Sharing ideas and progress
+- Mentoring others
+- Challenging yourself
+- Bringing others in to contribute
+- Asking for help and making new contacts
+
+If there's any doubt please don't hesitate to contact the issue creator or the project maintainers - we'd love to help out!
+
+If you start addressing an issue please assign yourself to it by posting the `/assign` message in the issue; this will help maintainers know exactly who is working on it and let others know that the issue has already been picked up by someone.
+
+### Project ideas with Hacktoberfest queries
+
+- [Catalog](https://github.com/tektoncd/catalog/labels/hacktoberfest-accepted)
+- [Chains](https://github.com/tektoncd/chains/labels/hacktoberfest-accepted)
+- [CLI](https://github.com/tektoncd/cli/labels/hacktoberfest-accepted)
+- [Dashboard](https://github.com/tektoncd/dashboard/labels/hacktoberfest-accepted)
+- [Results](https://github.com/tektoncd/results/labels/hacktoberfest-accepted)
+- [Experimental](https://github.com/tektoncd/experimental/labels/hacktoberfest-accepted)
+- [Website](https://github.com/tektoncd/website/labels/hacktoberfest-accepted)
+- [Pipeline](https://github.com/tektoncd/pipeline/labels/hacktoberfest-accepted)
+- [Triggers](https://github.com/tektoncd/triggers/labels/hacktoberfest-accepted)
+
+### More information on Hacktoberfest, recognition and our FAQ!
+
+Check out our [CDF Hacktoberfest page!](https://cd.foundation/hacktoberfest/) If anything's unclear please reach out to the CDF on [our CDF Slack](https://cdeliveryfdn.slack.com).
+
+You can also refer to the [official guidelines](https://hacktoberfest.digitalocean.com/hacktoberfest-update) (including the label to use and the topics for each repo we should have).


### PR DESCRIPTION
This is taken from the 2020 version and slightly adapated.
Project maintainers should label issues if they are interested
in partecipating.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>