### PR TITLE
TEP-0085: Per-Namespace Controller Configuration [Rename]

### DIFF
--- a/teps/0085-per-namespace-controller-configuration.md
+++ b/teps/0085-per-namespace-controller-configuration.md
@@ -1,6 +1,6 @@
 ---
 status: proposed
-title: Custom Configuration
+title: Per-Namespace Controller Configuration
 creation-date: '2021-08-25'
 last-updated: '2021-10-14'
 authors:

--- a/teps/README.md
+++ b/teps/README.md
@@ -224,4 +224,4 @@ This is the complete list of Tekton teps:
 |[TEP-0080](0080-support-domainscoped-parameterresult-names.md) | Support domain-scoped parameter/result names | implemented | 2021-08-19 |
 |[TEP-0081](0081-add-chains-subcommand-to-the-cli.md) | Add Chains sub-command to the CLI | proposed | 2021-08-31 |
 |[TEP-0084](0084-endtoend-provenance-collection.md) | end-to-end provenance collection | proposed | 2021-09-16 |
-|[TEP-0085](0085-custom-configuration.md) | Custom Configuration | proposed | 2021-10-14 |
+|[TEP-0085](0085-per-namespace-controller-configuration.md) | Per-Namespace Controller Configuration | proposed | 2021-10-14 |


### PR DESCRIPTION
In https://github.com/tektoncd/community/pull/506, we added a TEP for Per-Namespace Controller Configuration. We had previously named it "Custom Configuration" but it wasn't descriptive enough. When we renamed it, we missed to make the change in a few places. In this commit we fix the missed renaming.

[TEP-0085: Per-Namespace Controller Configuration](https://github.com/tektoncd/community/blob/main/teps/0085-custom-configuration.md). 

/cc @sbwsg @pritidesai 