### PR TITLE
Add GitHub Team for Governing Board

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -146,6 +146,15 @@ orgs:
     - zhangtbj
     - ziheng
     teams:
+      governing-board:
+        description: Tekton Governing Board members
+        members:
+        - abayer
+        - bobcatfish
+        - vdemeester
+        - afrittoli
+        - dibyom
+        privacy: closed
       catalog.maintainers:
         description: the catalog maintainers
         maintainers:


### PR DESCRIPTION
This is a simple GitHub team definition for the Governing Board.

I tried to @mention the board on PR, but there wasn't an existing team that let me do what I wanted.