### PR TITLE
TEP-0073: Update TEP with a link to a related github issue

### DIFF
--- a/teps/0073-simplify-metrics.md
+++ b/teps/0073-simplify-metrics.md
@@ -2,7 +2,7 @@
 status: proposed
 title: Simplify metrics
 creation-date: '2021-06-23'
-last-updated: '2021-06-23'
+last-updated: '2021-11-01'
 authors:
 - "@vdemeester"
 - "@yaoxiaoqi"
@@ -420,7 +420,8 @@ It will be a quick reference for those looking for implementation of this TEP.
 
 Additional context for this TEP can be found in the following links:
 
-- [Github issues](https://github.com/tektoncd/pipeline/issues/2842)
+- [Related Github Issue: Too much tekton metrics](https://github.com/tektoncd/pipeline/issues/2842)
+- [Related Github Issue: Metrics Retention](https://github.com/tektoncd/pipeline/issues/4340)
 - [metrics.md](https://github.com/tektoncd/pipeline/blob/master/docs/metrics.md)
 - [Prometheus Metrics Limitation](https://docs.sysdig.com/en/limit-prometheus-metric-collection.html)
 - [SRVKP-1528 Possible cardinality issue with tekton pipelines metrics](https://issues.redhat.com/browse/SRVKP-1528)

--- a/teps/README.md
+++ b/teps/README.md
@@ -220,7 +220,7 @@ This is the complete list of Tekton teps:
 |[TEP-0070](0070-tekton-catalog-task-platform-support.md) | Platform support in Tekton catalog | proposed | 2021-06-02 |
 |[TEP-0071](0071-custom-task-sdk.md) | Custom Task SDK | proposed | 2021-06-15 |
 |[TEP-0072](0072-results-json-serialized-records.md) | Results: JSON Serialized Records | implementable | 2021-07-26 |
-|[TEP-0073](0073-simplify-metrics.md) | Simplify metrics | proposed | 2021-06-23 |
+|[TEP-0073](0073-simplify-metrics.md) | Simplify metrics | proposed | 2021-11-01 |
 |[TEP-0074](0074-deprecate-pipelineresources.md) | Deprecate PipelineResources | proposed | 2021-10-25 |
 |[TEP-0080](0080-support-domainscoped-parameterresult-names.md) | Support domain-scoped parameter/result names | implemented | 2021-08-19 |
 |[TEP-0081](0081-add-chains-subcommand-to-the-cli.md) | Add Chains sub-command to the CLI | implementable | 2021-10-21 |


### PR DESCRIPTION
TEP 0073 describes simplifying the metrics that Tekton Pipelines records for TaskRuns.

A user over in the Tekton Pipelines repo requested a similar change, so this commit records that request.