### PR TITLE
Require TEP-0044 before removing PipelineResources 🙋‍♀️

### DIFF
--- a/teps/0074-deprecate-pipelineresources.md
+++ b/teps/0074-deprecate-pipelineresources.md
@@ -2,7 +2,7 @@
 status: proposed
 title: Deprecate PipelineResources
 creation-date: '2021-07-14'
-last-updated: '2021-10-25'
+last-updated: '2021-11-05'
 authors:
 - '@bobcatfish'
 ---
@@ -160,8 +160,8 @@ that maybe this concept, at least in its current form, isn't required).
     * [TEP-0075 Object/Dictionary support](https://github.com/tektoncd/community/pull/479) must be at a beta level of
       stability
     * [TEP-0076 Array support](https://github.com/tektoncd/community/pull/479) must be at a beta level of stability
-    * [pipeline-to-taskrun experimental custom task](https://github.com/tektoncd/experimental/pull/770) must be used in
-      dogfooding, as a way to prove the viability of a solution to [TEP-0044](https://github.com/tektoncd/community/blob/main/teps/0044-decouple-task-composition-from-scheduling.md)
+    * [TEP-0044 Decouple Task Composition from Scheduling](https://github.com/tektoncd/community/blob/main/teps/0044-decouple-task-composition-from-scheduling.md)
+      must be implemented at an alpha level of stability, to give users a reasonable migration path off of PipelineResources for v1
 1. If any of these TEPs this proposal depends on are rejected, we must create a new TEP to fill the gap in functionality
    before moving forward
 1. [Once we meet these requirements](#requirements-to-mark-as-implementable), update this TEP to be `implementable`
@@ -183,6 +183,8 @@ that maybe this concept, at least in its current form, isn't required).
 - [ ] [TEP-0056 Pipelines in Pipelines](https://github.com/tektoncd/community/blob/main/teps/0056-pipelines-in-pipelines.md) is implemented and promoted to beta
 - [ ] [TEP-0075 Object/Dictionary support](https://github.com/tektoncd/community/pull/479) is implemented and promoted to beta
 - [ ] [TEP-0076 Array support](https://github.com/tektoncd/community/pull/479) is implemented and promoted to beta
+- [ ] [TEP-0044 Decouple Task Composition from Scheduling](https://github.com/tektoncd/community/blob/main/teps/0044-decouple-task-composition-from-scheduling.md)
+  is implemented at alpha
   
 ### New repo: tektoncd/images
 
@@ -235,9 +237,6 @@ Possible alternative tweaks:
        implementable (which is itself blocked on [TEP-0076 Array support](https://github.com/tektoncd/community/pull/479)),
        being implemented, and being promoted from an alpha feature to beta
     1. Assume it is okay to accept this TEP while these are still WIP:
-      * [TEP-0044](https://github.com/tektoncd/community/blob/main/teps/0044-decouple-task-composition-from-scheduling.md):
-        it will likely be a while before we fully explore this, in the meantime, we can prove (see above) that a
-        Pipeline running as a pod based approach is viable
       * [TEP-0030 Workspace Paths](https://github.com/tektoncd/community/blob/main/teps/0030-workspace-paths.md)): this
         functionality doesn't seem to be as important to any users as the rest of the PipelineResources features
 * Risk: Migration to v1 will be harder for people who are using PipelineResources

--- a/teps/README.md
+++ b/teps/README.md
@@ -221,7 +221,7 @@ This is the complete list of Tekton teps:
 |[TEP-0071](0071-custom-task-sdk.md) | Custom Task SDK | proposed | 2021-06-15 |
 |[TEP-0072](0072-results-json-serialized-records.md) | Results: JSON Serialized Records | implementable | 2021-07-26 |
 |[TEP-0073](0073-simplify-metrics.md) | Simplify metrics | proposed | 2021-11-01 |
-|[TEP-0074](0074-deprecate-pipelineresources.md) | Deprecate PipelineResources | proposed | 2021-10-25 |
+|[TEP-0074](0074-deprecate-pipelineresources.md) | Deprecate PipelineResources | proposed | 2021-11-05 |
 |[TEP-0080](0080-support-domainscoped-parameterresult-names.md) | Support domain-scoped parameter/result names | implemented | 2021-08-19 |
 |[TEP-0081](0081-add-chains-subcommand-to-the-cli.md) | Add Chains sub-command to the CLI | implementable | 2021-10-21 |
 |[TEP-0082](0082-workspace-hinting.md) | Workspace Hinting | proposed | 2021-10-26 |


### PR DESCRIPTION
The Google Tekton team was discussing plans for 2022 and we were trying
to figure out how important pipeline in a pod was - based on the initial
requirements here for PipelineResource deprecation, it felt like we'd be
able to go ahead (specifically with Pipelines v1!) without pipeline in a
pod. The existing requirements said we'd need experimental support to
prove it was possible - however when thinking through what that would
mean for v1, i.e.: pipelineresources are now gone, and you need to use
this experimental custom task if you want the same "in a pod"
functionality - that didn't seem fair to users.

So this change would update our requirements so that we'd have at least
alpha support for "pipeline in a pod" functionality before we'd mark
this TEP as implementable, i.e. before actually removing any
PipelineResoruce functionality from our API surface.