### PR TITLE
Make "use cases" section required 📝

### DIFF
--- a/teps/tools/tep-template.md.template
+++ b/teps/tools/tep-template.md.template
@@ -59,7 +59,7 @@ tags, and then generate with `hack/update-toc.sh`.
 - [Motivation](#motivation)
   - [Goals](#goals)
   - [Non-Goals](#non-goals)
-  - [Use Cases (optional)](#use-cases-optional)
+  - [Use Cases](#use-cases)
 - [Requirements](#requirements)
 - [Proposal](#proposal)
   - [Notes/Caveats (optional)](#notescaveats-optional)
@@ -121,7 +121,7 @@ What is out of scope for this TEP?  Listing non-goals helps to focus discussion
 and make progress.
 -->
 
-### Use Cases (optional)
+### Use Cases
 
 <!--
 Describe the concrete improvement specific groups of users will see if the


### PR DESCRIPTION
I noticed that the use cases section is optional but also I think many
(most? all?) of our TEP discussions end up coming down to "what are the
use cases" so I think it's a bit misleading to claim this section is
optional when it ends up being so important in our discussions, so this
commit changes it to be a required section