### PR TITLE
[TEP-0044] Add more details to alternatives 🔍

### DIFF
--- a/teps/0044-decouple-task-composition-from-scheduling.md
+++ b/teps/0044-decouple-task-composition-from-scheduling.md
@@ -2,7 +2,7 @@
 status: proposed
 title: Decouple Task Composition from Scheduling
 creation-date: '2021-01-22'
-last-updated: '2021-12-07'
+last-updated: '2021-12-14'
 authors:
 - '@bobcatfish'
 - '@lbernick'
@@ -147,16 +147,28 @@ See [TEP-0074](./0074-deprecate-pipelineresources.md) for the deprecation plan f
 
 ## Requirements
 
-- Tasks can be composed and run together:
+1. Tasks can be composed and run together:
   - Must be able to share data without requiring a volume external to the pod
   - Must be possible to run multiple Tasks as one pod
-- It should be possible to have Tasks that run even if others fail; i.e. the Task
+1. It should be possible to have Tasks that run even if others fail; i.e. the Task
   can be run on the same pod as another Task that fails
   - This is to support use cases such as uploading test results, even if the test
     Task failed
     - This requirement is being included because we could choose a solution that doesn't
       address the above use case; for example in PipelineResources, you can have a
       storage "output" but if the steps fail, the "output" pipelineresource will not run
+1. It must be possible for Tasks within a Pipeline that is run in this manner to be able to specify different levels
+  of [hermeticity](https://github.com/tektoncd/community/blob/main/teps/0025-hermekton.md)
+  - For example, a Task that fetching dependencies may need to run in non-hermetic mode, but the Task that actually
+    builds an artifact using these dependencies may need to be hermetic (e.g. 
+1. Information about the status of individually executing Tasks must still be surfaced in a way such that
+   in the `status` of the PipelineRun, the execution of each individual Task (including its results) can be viewed
+   separately
+    - i.e. even if multiple Tasks execute as one pod, the results of each execution should be displayed to the user
+      separately in the `status`
+    - [PipelineRuns currently specify this information in a `taskruns` section ](https://github.com/tektoncd/pipeline/blob/main/docs/pipelineruns.md#monitoring-execution-status)
+      so if the execution method ends up not being individual `TaskRuns` we may need to either create "fake" taskruns
+      to populate, or create a new section with different status information
 
 ## Design details
 
@@ -164,24 +176,42 @@ TBD - currently focusing on enumerating and examining alternatives before select
 
 ## Alternatives
 
-Most of these options are not mutually exclusive:
+[Implementation options](#implementation-options):
+  * In the general theme of running [more than one Task in one pod](#more-than-one-task-in-one-pod):
+    * [Pipeline executed as pod](#pipeline-executed-as-pod)
+    * [Pipeline executed as TaskRun](#pipeline-executed-as-taskrun)
+    * [TaskRun controller composes pods from multiple TaskRuns](#taskrun-controller-composes-one-pod-from-multiple-taskruns)
+* [Other implementation options](#other-implementation-options):
+  * [Custom scheduler](#custom-scheduler)
+  * [Support other ways to share data (e.g. buckets)](#support-other-ways-to-share-data-eg-buckets)
+[Syntax options](#syntax-options) for running more than one Task in one pod:
+* [At authoring time](#at-authoring-time)
+  * [In the Pipeline](#in-the-pipeline)
+    * [Task composition in Pipeline Tasks](#task-composition-in-pipeline-tasks)
+      * [Using pipelines in pipelines](#-using-pipelines-in-pipelines)
+      * [init/before finally/after](#-initbefore-finallyafter)
+    * [Automatically combine Tasks based on workspace use](#automagically-combine-tasks-based-on-workspace-use)
+    * [Introduce scheduling rules to Pipeline](#introduce-scheduling-rules-to-pipeline)
+    * [Focus on workspaces](#focus-on-workspaces)
+  * [In the Task](#within-the-task)
+  * [Other](#other-authoring-time-options)
+    * [Remove distinction between Tasks and Pipelines](#remove-distinction-between-tasks-and-pipelines)
+    * [Create a new Grouping CRD](#create-a-new-grouping-crd)
+    * [Custom Pipeline](#custom-pipeline)
+* [At runtime](#runtime-instead-of-authoring-time)
+  * [PipelineRun: emptyDir](#pipelinerun-emptydir)
+  * [Controller configuration](#controller-level)
 
-* [Task composition in Pipeline Tasks](#task-composition-in-pipeline-tasks)
-* [Update PipelineResources to use Tasks](#update-pipelineresources-to-use-tasks)
-* [Automatically combine Tasks based on workspace use](#automagically-combine-tasks-based-on-workspace-use)
-* [Introduce scheduling rules to Pipeline](#introduce-scheduling-rules-to-pipeline)
-* [PipelineRun: emptyDir](#pipelinerun-emptydir)
-* [Controller configuration](#controller-level)
-* [Within the Task](#within-the-task)
-* [Remove distinction between Tasks and Pipelines](#remove-distinction-between-tasks-and-pipelines)
-* [Custom Pipeline](#custom-pipeline)
-* [Create a new Grouping CRD](#create-a-new-grouping-crd)
-* [Custom scheduler](#custom-scheduler)
-* [Support other ways to share data (e.g. buckets)](#support-other-ways-to-share-data-eg-buckets)
-* [Focus on workspaces](#focus-on-workspaces)
+### Implementation options
 
-Most of the solutions above involve allowing more than one Task to be run in the same pod, and those proposals all share
-the following pros & cons.
+This section describes various ways that the functionality we're proposing could be implemented, which we can make
+choices around somewhat independently of deciding
+[what syntax we want to create to support this](#syntax-options).
+
+#### More than one Task in one pod
+
+The implementation options in this section are variations on the idea that the steps in the Tasks that make up a
+Pipeline are ultimately executed in one pod, supported by [some syntax](#syntax-options).
 
 Pros:
 * Making it possible to execute a Pipeline in a pod will also pave the way to be able to support use cases such as
@@ -189,15 +219,313 @@ Pros:
 
 Cons:
 
-* Increased complexity around requesting the correct amount of resources when scheduling (having to look at the
-  requirements of all containers in all Tasks, esp. when they run in parallel)
+* Some Pipeline functionality may not be possible in a pod, see [supported functionality](#supported-functionality)
 * Requires re-architecting and/or duplicating logic that currently is handled outside the pods in the controller
   (e.g. passing results between Tasks and other variable interpolation)
+* Increased complexity around requesting the correct amount of resources when scheduling (having to look at the
+  requirements of all containers in all Tasks, esp. when they run in parallel)
+* Not clear how we represent the status of a Pipeline executed as a pod; i.e. do we create fake taskRuns for the
+  purposes of populating the Pipeline status (i.e. expose the status of a group of steps corresponding to one Task as
+  if they were run as a TaskRun) or simply expose it as one big TaskRun (probably not the user experience we want)
+  * We can probably find a new syntax for representing the individual tasks inside of a Pipeline executed in this way,
+    e.g. a section for each task in the pipeline, containing a subset of the overall pod status (specifically the
+    containers, results, etc., which pertain to that task)
+
+##### Supported functionality
+
+When executing an entire Pipeline as a pod, some functionality will be easily translated, some will require significant
+work, and some may not be possible in a pod. This is an initial estimate of what we can support and changes it would
+require.
+
+* Functionality that could be supported with current pod logic (e.g. by
+  [translating a Pipeline directly to a TaskRun](#pipeline-executed-as-taskrun)):
+  * Sequential tasks (specified using [`runAfter`](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#using-the-runafter-parameter))
+  * [String params](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#specifying-parameters)
+  * [Array params](https://github.com/tektoncd/pipeline/blob/main/docs/tasks.md#specifying-parameters)
+  * [Workspaces](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#specifying-workspaces)
+  * [Pipeline level results](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#emitting-results-from-a-pipeline)
+  * Workspace features:
+    * [mountPaths](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md#using-workspaces-in-tasks)
+    * [subPaths](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md#using-workspaces-in-pipelines)
+    * [optional](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md#optional-workspaces)
+    * [readOnly](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md#using-workspaces-in-tasks)
+    * [isolated](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md#isolating-workspaces-to-specific-steps-or-sidecars)
+  * Specifying Tasks in a Pipeline via [Bundles](https://github.com/tektoncd/pipeline/blob/main/docs/tekton-bundle-contracts.md)
+    (all bundles would have to be fetched before execution starts)
+  * [step templates](https://github.com/tektoncd/pipeline/blob/main/docs/tasks.md#specifying-a-step-template)
+  * [timeout](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#configuring-the-failure-timeout)
+* Functionality that could be supported with updated pod construction logic:
+  [Sidecars](https://github.com/tektoncd/pipeline/blob/main/docs/tasks.md#specifying-sidecars)
+  (may need to wrap sidecar commands such that sidecars don't start executing until their corresponding Task starts)
+* Functionality that would require additional orchestration within the pod (e.g. entrypoint changes):
+  * [Passing results between tasks](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#passing-one-tasks-results-into-the-parameters-or-whenexpressions-of-another)
+  * [retries](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#using-the-retries-parameter)
+  * Contextual variable replacement that assumes a PipelineRun, for example [`context.pipelineRun.name`](https://github.com/tektoncd/pipeline/blob/main/docs/variables.md#variables-available-in-a-pipeline)
+  * [Parallel tasks](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#configuring-the-task-execution-order)
+  * [When expressions](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#guard-task-execution-using-whenexpressions)
+    (and [Conditions](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#guard-task-execution-using-conditions))
+  * [Finally tasks](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#adding-finally-to-the-pipeline)
+  * [Allowing step failure](https://github.com/tektoncd/pipeline/blob/main/docs/tasks.md#specifying-onerror-for-a-step)
+* Functionality that would require significantly expanded orchestration logic:
+  * [Custom tasks](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#using-custom-tasks) - the pod would
+    need to be able to create and watch Custom Tasks, or somehow lean on the Pipelines controller to do this
+* Functionality that might not be possible (i.e. constrained by pods themselves):
+  * Any dynamically created TaskRuns, e.g. dynamic looping based on Task results
+    (from [TEP-0090 matrix support](https://github.com/tektoncd/community/pull/532)) since
+    [a pod's containers cannot be updated](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podspec-v1-core)
+  * Running each Task with a different `ServiceAccount` - the pod has one ServiceAccount as a whole
+
+(See also [functionality supported by experimental Pipeline to TaskRun](https://github.com/tektoncd/experimental/tree/main/pipeline-to-taskrun#supported-pipeline-features))
+
+##### Pipeline executed as pod
+
+In this implementation, when a Pipeline is executed as a pod, the Tekton Pipelines controller would construct a pod
+that implements that Pipeline.
+
+Pros:
+* Uses [an existing abstraction](https://github.com/tektoncd/community/blob/main/design-principles.md#reusability)
+  (Pipelines)
+* Pipelines already have syntax for expressing some of the features we'd likely want for this functionality, e.g.
+  `finally`
+Cons:
+* Using an existing abstraction (Pipelines) could be confusing if we can't support all of a Pipeline's functionality
+  when running as a pod (which is likely)
+
+##### Pipeline executed as TaskRun
+
+This is the approach currently taken in the
+[Pipeline to TaskRun experimental custom task](https://github.com/tektoncd/experimental/tree/main/pipeline-to-taskrun).
+
+Cons:
+* We would be [limited in the features we could support](https://github.com/tektoncd/experimental/tree/main/pipeline-to-taskrun#supported-pipeline-features)
+  to features that TaskRuns already support, or we'd have to add more Pipeline features to TaskRuns.
+
+##### TaskRun controller composes one pod from multiple TaskRuns
+
+The goal behind this implementation would be that we still create multiple TaskRuns for a Pipeline, but those TaskRuns
+ultimately get executed as one pod.
+
+A pod will start executing once it has been created and many of the fields (including the containers list)
+[cannot be updated](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podspec-v1-core).
+If we wanted to use one pod to execute an entire Pipeline, we would need to be aware of all of the containers that need
+to be in that pod before the pod was created. The PipelineRun controller currently only creates TaskRuns which are
+ready to executed, but in order to the pod which represents all of the TaskRuns that will ultimately represent the
+PipelineRun, the Pipeline controller would need to create all TaskRuns at once, with the TaskRuns that are not ready
+to execute in a pending state.
+
+As the TaskRun controller (or some new controller for this specific purpose) reconciled the TaskRuns that make up the
+Pipeline, it would need to:
+1. Be able to save state across reconcile loops that would represent the eventual pod and update it as it reconciled.
+   Since the relevant fields in the pod itself [cannot be updated](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podspec-v1-core)
+   this would have to be done somewhere else, e.g. in memory in the controller or in `ConfigMap`.
+2. The controller would need to be able to know when it had resolved all of the relevant TaskRuns (and so it was time
+   to actually start the pod); since we can't guarantee the order the TaskRun controller will reconcile the TaskRuns
+   in, each TaskRun created this way would probably need to contain information on how many TaskRuns to expect, or
+   possibly even the names of the related TaskRuns
+
+Pros:
+* This maintains the existing relationships between the Pipelines resources
+  (N Tasks -> 1 Pipeline -> 1 PipelineRun -> N TaskRun)
+* Having the Pipeline controller create TaskRuns up front (as "pending" or similar) might have other benefits, for
+  example we've struggled in the past with how to represent the status of Tasks in a Pipeline which don't have a
+  backing TaskRun, e.g. they are skipped or cancelled. Now there actually would be a TaskRun backing them.
+  * This would not be possible for any dynamically created TaskRuns, e.g. dynamic looping based on Task results
+    (from [TEP-0090 matrix support](https://github.com/tektoncd/community/pull/532))
+
+Cons:
+* Have to create all TaskRuns in advance (at least in this specific scenario)
+* Creating the underlying pod is more complicated than other options in that:
+  * It happens across multiple reconciles
+  * It requires state to be maintained across reconciles
+  * It requires co-ordination information about the Pipeline as a whole to be contained in corresponding TaskRuns
+
+#### Other implementation options
+
+##### Custom scheduler
+
+In this approach we use a custom scheduler to schedule our pods.
+
+Cons:
+* [@jlpetterson has explored this option](https://docs.google.com/document/d/1lIqFP1c3apFwCPEqO0Bq9j-XCDH5XRmq8EhYV_BPe9Y/edit#heading=h.18c0pv2k7d1a)
+  and felt it added more complexity without much gain (see also https://github.com/tektoncd/pipeline/issues/3052)
+  * For example the issue [#3049](https://github.com/tektoncd/pipeline/issues/3049)
+* Doesn't help us with the overhead of multiple pods (each Task would still be a pod)
+
+##### Support other ways to share data (e.g. buckets)
+
+In this approach we could add more workspace types that support other ways of sharing data between pods, for example
+uploading to and downloading from s3. (See [#290](https://github.com/tektoncd/community/pull/290/files).)
+
+[This is something we support for "linking" PipelineResources.](https://github.com/tektoncd/pipeline/blob/master/docs/install.md#configuring-pipelineresource-storage)
+
+Pros:
+* Easier out of the box support for other ways of sharing data
+
+Cons:
+* Uploading and downloading at the beginning and end of every Task is not as efficient as being able to share the same
+  disk
+* We'd need to define an extension mechanism so folks can use whatever backing store they want
+* Doesn't help us with the overhead of multiple pods (each Task would still be a pod)
+
+### Syntax options
+
+This section describes syntax options for [running more than one Task in a pod](#more-than-one-task-in-one-pod) which
+can be backed by the [implementation options](#implementation-options) above.
+
+#### At authoring time
+
+These options introduce syntax at [authoring time](https://github.com/tektoncd/community/blob/main/design-principles.md#reusability),
+i.e. when a Pipeline (or other reusable type) is being written.
+
+##### In the Pipeline
+
+These options introduce a syntax into the exiting Pipeline type.
+
+###### Task composition in Pipeline Tasks
+
+In this option we make it possible to express Tasks which can be combined together to run sequentially as one pod
+within a Pipeline.
+
+####### Using Pipelines in Pipelines
+
+In this option, we leverage whatever syntax would be added to support
+[TEP-0056 pipelines in pipelines](https://github.com/tektoncd/community/blob/main/teps/0056-pipelines-in-pipelines.md)
+and add a mode to indicate that the pipeline (in pipeline) is intended to run in a pod.
+
+This would mean:
+- Adding a syntax to Pipelines to support "run in a pod mode"
+- Adding a syntax to a PipelineRun to indicate the entire Pipeline should run "in a pod"
+- `PipelineRuns` that ran in this mode could fail due to [unsupported functionality](#supported-functionality)
+
+Example new `PipelineRun` syntax:
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: running-in-a-pod
+spec:
+  pipelineRef:
+    name: build-test-deploy # references some existing Pipeline or embeds a Pipeline
+  execution/scheduling: "co-located"/"isolated" # new syntax, "isolated" is the default
+  params:
+    ...
+  workspaces:
+    ...
+```
+
+The new option definitely needs some wordsmithing but the idea would be to capture an option that indicates that either
+the tasks that make up the Pipelines should run together sharing the same execution context (i.e. in a pod) or they run
+as they do today, with each Task being mapped to a pod and run separately.
+
+[TEP-0056 pipelines in pipelines](https://github.com/tektoncd/community/blob/main/teps/0056-pipelines-in-pipelines.md)
+comes into play because the pipelines in pipelines feature combined with the ability to run a PipelineRun "as a pod"
+allows users to compose Pipelines in which some tasks are scheduled as they are today and some are grouped together
+for execution as a pod.
+
+For example say we have this `Pipeline` which runs unit tests and uploads results:
+
+```yaml
+kind: Pipeline
+metadata:
+  name: unit-tests
+spec:
+  workspaces:
+    - name: source-code
+    - name: test-results
+  tasks:
+    - name: run-unit-tests
+      runAfter: get-source
+      taskRef:
+        name: just-unit-tests
+      workspaces:
+        - name: source-code
+          workspcae: source-code
+        - name: test-results
+          workspace: test-results
+  finally:
+    - name: upload-results
+      runAfter: run-unit-tests
+      taskRef:
+        name: gcs-upload
+      params:
+        - name: location
+          value: gs://my-test-results-bucket/testrun-$(taskRun.name)
+      workspaces:
+        - name: data
+          workspace: test-results
+    - name: update-slack
+      params:
+        - name: message
+          value: "Tests completed with $(tasks.run-unit-tests.status) status"
+```
+
+We could leverage
+[TEP-0056 pipelines in pipelines](https://github.com/tektoncd/community/blob/main/teps/0056-pipelines-in-pipelines.md):
+to run this Pipeline within another as a pod, for example:
 
 
-### Task composition in Pipeline Tasks
+```yaml
+kind: Pipeline
+metadata:
+  name: build-test-deploy
+spec:
+  workspaces:
+    - name: source-code
+  tasks:
+    - name: get-source
+      workspaces:
+        - name: source-code
+          workspace: source-code
+      taskRef:
+        name: git-clone
+      params:
+        - name: url
+            value: $(params.url)
+        - name: revision
+          value: $(params.revision)
+    - name: run-unit-tests-and-upload-results
+      runAfter: get-source
+      pipelineRef: # syntax may look different as TEP-0056 but the idea is that this is a Pipeline (in a pipeline) instead of a Task or Run
+        name: unit-tests
+      execution/scheduling: "co-located" # this pipeline in a pipeline should run in a pod
+      workspaces:
+        - name: source-code
+          workspcae: source-code
+    - name: deploy
+      runAfter: [run-unit-tests-and-upload-results]
+      when:
+        - input: "$(params.git-branch)"
+          operator: in
+          values: ["main"]
+      taskRef:
+        name: build-deploy
+      workspaces:
+        - name: source-code
+          workspcae: source-code
+```
 
-In this option we make it possible to express Tasks which can be combined together to run sequentially as one pod.
+In the above Pipeline, the Task `git-clone` would run as a pod, the Pipeline `unit-test` would be executed as a pod
+(by creating a PipelineRun using the new syntax) - including two `finally` Tasks, and the Task `build-deploy` would run
+as a pod.
+
+The Pipeline `unit-test` also takes a workspace `test-results` but when executing as a pod, this can be satisfied by
+`emptyDir`, so in the Pipeline above that runs `unit-test` as a Pipeline in a pod, it skips specifying this and since
+the execution mode is `co-located` the PipelineRun can be constructed to pass `emptyDir` (or that could be the
+implied default for any workspaces when a PipelineRun is run in `co-located` mode).
+
+Pros:
+* Doesn't involve introduction of new types
+* Assuming
+  [TEP-0056 pipelines in pipelines](https://github.com/tektoncd/community/blob/main/teps/0056-pipelines-in-pipelines.md)
+  users can construct composition of Pipelines however they'd like (i.e. parts of a Pipeline in a pod, parts not)
+Cons:
+* A Pipeline run in "co-located" mode could itself contain Pipelines to run in "co-located" mode which might be a bit
+  weird (and this nesting could continue.... infinitely?)
+  * Ultimately this would mean the entire flattened Pipeline would run in a pod so it shouldn't be ambiguous
+  * Probably makes sense for Pipeline in Pipeline to have some kind of depth limit defined anyway?
+
+####### init/before finally/after
 
 In the following example, 3 Tasks will be combined and run in one pod sequentially:
 
@@ -268,8 +596,8 @@ Related:
 * [TEP-0054](https://github.com/tektoncd/community/pull/369) suggests something similar to this but:
   * Uses "steps" as the unit
   * Wants to combine these in the embedded Task spec vs in the Pipeline Task
-  
-### Automagically combine Tasks based on workspace use
+
+###### Automagically combine Tasks based on workspace use
 
 In this option we could leave Pipelines as they are, but at runtime instead of mapping a Task to a pod, we could decide
 what belongs in what pod based on workspace usage.
@@ -333,7 +661,6 @@ Possible tweaks:
 * We could do this scheduling only when
   [a Task requires a workspace `from` another Task](https://github.com/tektoncd/pipeline/issues/3109).
 * We could combine this with other options but have this be the default behavior
-  
 
 Pros:
 * Doesn't require any changes for Pipeline or Task authors
@@ -345,11 +672,11 @@ Cons:
     * We could mitigate this by adding more configuration, e.g. opt in or out at a Pipeline level, but could get
       complicated if people want more control (e.g. opting in for one workspace but not another)
 
-### Introduce scheduling rules to pipeline
+###### Introduce scheduling rules to pipeline
 
 In these options, we add some syntax that allows Pipeline authors to express how they want Tasks to be executed.
 
-#### Add "grouping" to tasks in a pipeline
+####### Add "grouping" for tasks in a pipeline
 
 In this option we add some notion of "groups" into a Pipeline; any Tasks in a group will be scheduled together.
 
@@ -426,17 +753,325 @@ Cons:
 * Might be hard to reason about what is executed together
 * Might be hard to reason about what which Tasks can be combined in a group and which can't
 
-#### some other directive, e.g. labels, to indicate what should be scheduled together?
+####### some other directive, e.g. labels, to indicate what should be scheduled together?
 
 This option is the same as the previous `groups` proposal but maybe we decide on some other ways to indicating grouping,
 e.g. labels.
 
-### Runtime instead of authoring time
+###### Focus on workspaces
+
+This approach assumes that our main issue is around how to deal with data in a workspace:
+
+1. Before we run our logic
+2. After we're done with our logic
+
+(Where "logic" means whatever we're actually trying to do; i.e. getting the data to act on and doing something with the
+results are not the main concern of whatever our Pipeline is doing.)
+
+In the following example, the first thing the Pipeline will do is run `git-clone` to initialize the contents of the
+`source-code` workspace; after the Pipeline finishes executing, `gcs-upload` will be called to do whatever is needed
+with the data in the `test-results` workspace.
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: build-test-deploy
+spec:
+ params:
+  - name: url
+    value: https://github.com/tektoncd/pipeline.git
+  - name: revision
+    value: v0.11.3
+ workspaces:
+   - name: source-code
+     init:
+     - taskRef: git-clone
+       params:
+       - name: url
+         value: https://github.com/tektoncd/pipeline.git
+       - name: revision
+         value: v0.11.3
+   - name: test-results
+     teardown:
+     - taskRef: gcs-upload
+       params:
+       - name: location
+         value: gs://my-test-results-bucket/testrun-$(taskRun.name)
+ tasks:
+ - name: run-unit-tests
+   taskRef:
+     name: just-unit-tests
+   workspaces:
+    - name: source-code
+    - name: test-results
+```
+
+Workspace init and teardown could be done either for every Task (which could be quite a bit of overhead) or once for the
+Pipeline.
+
+Pros:
+* Solves one specific problem: getting data on and off of workspaces
+
+Cons:
+* Helps with our conceptual problems but not with our efficiency problems
+* The difference between a workspace teardown and finally could be confusing
+
+Related:
+* [Task Specialization: most appealing options?](https://docs.google.com/presentation/d/12QPKFTHBZKMFbgpOoX6o1--HyGqjjNJ7own6KqM-s68)
+
+##### Within the Task
+
+In this option we ignore the "not at Task authoring time" requirement and we allow for Tasks to contain other Tasks.
+
+This is similar to [TEP-0054](https://github.com/tektoncd/community/pull/369) which proposes this via the Task spec
+in a Pipeline, but does not (yet) propose it for Tasks outside of Pipelines.
+
+For example:
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: build-test-upload
+spec:
+  workspaces:
+  - name: source
+    mountPath: /workspace/source/go/src/github.com/GoogleContainerTools/skaffold
+  steps:
+  - name: get-source
+    uses: git-clone
+    params:
+      url: $(params.url)
+    workspaces:
+    - name: source
+      workspace: source
+  - name: run-tests
+    image: golang
+    workingDir: $(workspaces.source.path)
+    script: |
+      go test <stuff here>
+  - name: upload-results
+    uses: gcs-upload
+```
+
+Pros:
+* Doesn't require many new concepts
+
+Cons:
+* Can create confusing chains of nested Tasks (Task A can contain Task B which can Contain Task C...)
+* Requires creating new Tasks to leverage the reuse (maybe embedded specs negate this?)
+* Doesn't help with parallel use cases
+
+##### Other authoring time options
+
+These options are at Authoring time but are not implemented as simply addition syntax in the existing `Pipeline` and
+`Task` types.
+
+###### Remove distinction between Tasks and Pipelines
+
+In this version, we try to combine Tasks and Pipelines into one thing; e.g. by getting rid of Pipelines and adding all
+the features they have to Tasks, and by giving Tasks the features that Pipelines have which they do not have.
+
+Things Tasks can do that Pipelines can't:
+* Sidecars
+* Refer to images (including args to images like script, command, args, env....)
+
+Things Pipelines can do that Tasks can't:
+* Create DAGs, including running in parallel
+* Finally
+* When expressions
+
+For example, say our new thing is called a Process (altertively we could use one of our existing types, e.g. everything
+is now a Pipeline):
+
+```yaml
+kind: Process
+metadata:
+  name: git-clone
+spec:
+ workspaces:
+  - name: source-code
+ processes:
+ - name: get-source
+   steps:
+    - name: clone
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.21.0
+      script: <script here>
+   workspaces:
+   - name: source-code
+     workspace: source-code
+ finally:
+ # since we merged these concepts, any Process can have a finally
+```
+
+```yaml
+kind: Process
+metadata:
+  name: build-test-deploy
+spec:
+ params:
+ - name: git-branch
+ - name: go-version
+ workspaces:
+ - name: source-code
+ - name: test-results
+ processes: # processes could be steps, processRefs, or processes themselves
+ - name: get-test-upload # this process is itself a process (a process in a process)
+   processes:
+   - name: get-source
+     workspaces:
+     - name: source-code
+       workspace: source-code
+     processRef: # this process is a ref
+       name: git-clone # uses our process above
+   - name: run-unit-tests
+     runAfter: get-source
+     steps: # this process is steps
+    - name: unit-test
+      image: docker.io/library/golang:$(params.go-version)
+      script: <script here>
+     workspaces:
+     - name: source-code
+       workspcae: source-code
+     - name: test-results
+       workspace: test-results
+   - name: upload-results
+     runAfter: run-unit-tests
+     processRef:
+       name: gcs-upload
+     params:
+     - name: location
+       value: gs://my-test-results-bucket/testrun-$(taskRun.name)
+     workspaces:
+     - name: data
+       workspace: test-results
+ - name: deploy
+   runAfter: [get-test-upload]
+   when:
+   - input: "$(params.git-branch)"
+     operator: in
+     values: ["main"]
+   processRef:
+     name: build-deploy
+   workspaces:
+    - name: source-code
+      workspcae: source-code
+finally:
+- name: update-slack
+  params:
+  - name: message
+    value: "Tests completed with $(tasks.run-unit-tests.status) status"
+```
+
+Processes contain Processes, which can be defined as steps or reference to other Processes.
+
+We will need to add something to indicate how to schedule Processes now that we won't have the convenience of drawing the
+line around Tasks; we could combine this idea with one of the others in this proposal - likely we'd have to introduce
+new syntax to express scheduling, and/or we could have similar defaults (e.g. steps execute together in one pod).
+
+Pros:
+* Maybe the distinction between Tasks and Pipelines has just been making things harder for us
+* Maybe this is a natural progression of the "embedding" we already allow in pipelines?
+* We could experiment with this completely independently of changing our existing CRDs (as long as we don't want
+  Processes to be called `Task` or `Pipeline` XD - even then we could use a different API group)
+
+Cons:
+* Pretty dramatic API change; we'd likely have to keep supporting Tasks and Pipelines for a while and would be a pretty
+  big change if we didn't support them in v1. If we DID support all 3 in v1 (Tasks, Pipelines, this new thing), would
+  they work together? e.g. could a Process reference Pipelines
+* Processes can contain Processes can contain Processes can contain Processes
+  * However with [pipelines in pipelines (TEP-0056)](https://github.com/tektoncd/community/blob/main/teps/0056-pipelines-in-pipelines.md)
+    Pipelines can contain Pipelines which contain Pipelines
+
+###### Create a new Grouping CRD
+
+In this approach we create a new CRD, e.g. `TaskGroup` that can be used to group Tasks together. Pipelines can refer to
+TaskGroups, and they can even embed them.
+
+For example:
+
+```yaml
+kind: TaskGroup
+metadata:
+  name: build-test-deploy
+spec:
+ workspaces:
+  - name: source-code
+  - name: test-results
+ tasks:
+ - name: get-source
+   workspaces:
+   - name: source-code
+     workspace: source-code
+   taskRef:
+     name: git-clone
+   params:
+   - name: url
+      value: $(params.url)
+    - name: revision
+      value: $(params.revision)
+ - name: run-unit-tests
+   runAfter: get-source
+   taskRef:
+     name: just-unit-tests
+   workspaces:
+   - name: source-code
+     workspcae: source-code
+   - name: test-results
+     workspace: test-results
+ - name: upload-results
+   runAfter: run-unit-tests
+   taskRef:
+     name: gcs-upload
+   params:
+   - name: location
+     value: gs://my-test-results-bucket/testrun-$(taskRun.name)
+   workspaces:
+   - name: data
+     workspace: test-results
+```
+
+We could decide if we only support sequential execution, or support an entire DAG. Maybe even finally?
+
+An alternative to the above (which is an ["authoring time"](https://github.com/tektoncd/community/blob/main/design-principles.md#reusability)
+solution) would be a "runtime" CRD, e.g. `TaskGroupRun` which could be passed multiple Tasks and run them together.
+
+Pros:
+* Could be used to define different execution strategies
+
+Cons:
+* The line between this and a Pipeline seems very thin
+* New CRD to contend with
+* Will mean that both the Pipelines controller and this controller will need to share (or duplicate) a lot of
+  Pipeline logic
+
+###### Custom Pipeline
+
+This approach is very similar to [Grouping CRD](#grouping-crd) but instead of creating a new type in the Tekton API,
+the same functionality is implemented as a custom task.
+
+In this approach we solve this problem by making a Custom Task that can run a Pipeline using whatever scheduling
+mechanism is preferred; this assumes the custom task is the ONLY way we support a different scheduling than
+Task to pod going forward (even if we pick a different solution it could make sense to implement it as a custom task
+first).
+
+Pros:
+* Doesn't change anything about our API
+
+Cons:
+* If this custom task is widely adopted, could fork our user community (or we'd have to decide to promote it to a
+  part of the Tekton API - the main downside to making this a custom task first would be having to duplicate/reuse
+  the existing controller logic across 2 controllers, vs. deciding early we want this to be a first class feature
+  and keep all of the pipelines logic in the pipelines controller
+
+
+#### Runtime instead of authoring time
 
 These options pursue a solution that only works at runtime; this means Pipeline authors would not have any control
 over the scheduling.
 
-#### PipelineRun: emptyDir
+##### PipelineRun: emptyDir
 
 In this solution we use the values provided at runtime for workspaces to determine what to run. Specifically, we allow
 [`emptyDir`](https://github.com/tektoncd/pipeline/blob/a7ad683af52e3745887e6f9ed58750f682b4f07d/docs/workspaces.md#emptydir)
@@ -448,7 +1083,7 @@ For example given this Pipeline:
 ```yaml
 kind: Pipeline
 metadata:
-  name: build-test-deploy
+  name: unit-test
 spec:
  workspaces:
   - name: source-code
@@ -496,7 +1131,7 @@ metadata:
   name: run
 spec:
   pipelineRef:
-    name: build-test-deply
+    name: build-test-deploy
   workspaces:
   - name: source-code
     emptyDir: {}
@@ -546,20 +1181,20 @@ Pros:
 
 Cons:
 * If it's important for a Pipeline to be executed in a certain way, that information will have to be encoded somewhere
-  other than the Pipeline 
+  other than the Pipeline. When looking at a Pipeline definition, or writing it, you can't predict or control how the
+  Tasks will be co-located (e.g. what if you want to isolate some data such that it's only available to particular Tasks)
+* If you want to run a Pipeline, you'll need to make decisions at that point about what to co-locate. I can imagine
+  scenarios where folks want to make complex Pipelines and want to have some parts co-located and some parts not; if
+  we only allow for this at runtime, the Pipeline authors will only be able to provide docs or scripts (or
+  TriggerTemplates) to show folks how they are expected to be run.
 * For very large Pipelines, this default behavior may cause problems (e.g. if the Pipeline is too large to be scheduled
   into one pod)
 * A bit strange and confusing to overload the meaning of `emptyDir`, might be simpler and clearer to have a field instead
+  * Instead of overloading `emptyDir` we could add a new option e.g. `sharedWorkspace`, `localWorkspace` or a flag at
+    runtime to indicate that a workspace should be backed by a local directory and the Tasks that use it should run
+    together
 
-#### PipelineRun: field
-
-This is similar to the `emptyDir` based solution but instead of adding extra meaning to `emptyDir` we add a field to the
-runtime workspace information or to the entire PipelineRun (maybe when this field is set workspaces do not need to be
-provided.)
-
-A field could also be added as part of the Pipeline definition if desired (vs at runtime via a PipelineRun).
-
-#### Controller level
+##### Controller level
 
 This option is [TEP-0046](https://github.com/tektoncd/community/pull/318). In this option, the Tekton controller can
 be configured to always execute Pipelines inside one pod.
@@ -574,6 +1209,7 @@ Cons:
 * Executing a pipeline in a pod will require significantly re-architecting our graph logic so it can execute outside
   the controller and has a lot of gotchas we'll need to iron out (see
   [https://hackmd.io/@vdemeester/SkPFtAQXd](https://hackmd.io/@vdemeester/SkPFtAQXd) for some more brainstorming)
+* Users will not be able to control which Tasks are co-located with which: it will be all or nothing.
 
 ### Within the Task
 

--- a/teps/README.md
+++ b/teps/README.md
@@ -196,7 +196,7 @@ This is the complete list of Tekton teps:
 |[TEP-0040](0040-ignore-step-errors.md) | Ignore Step Errors | implemented | 2021-08-11 |
 |[TEP-0041](0041-tekton-component-versioning.md) | Tekton Component Versioning | implementable | 2021-04-26 |
 |[TEP-0042](0042-taskrun-breakpoint-on-failure.md) | taskrun-breakpoint-on-failure | implemented | 2021-12-10 |
-|[TEP-0044](0044-decouple-task-composition-from-scheduling.md) | Decouple Task Composition from Scheduling | proposed | 2021-12-07 |
+|[TEP-0044](0044-decouple-task-composition-from-scheduling.md) | Decouple Task Composition from Scheduling | proposed | 2021-12-14 |
 |[TEP-0045](0045-whenexpressions-in-finally-tasks.md) | WhenExpressions in Finally Tasks | implemented | 2021-06-03 |
 |[TEP-0046](0046-finallytask-execution-post-timeout.md) | Finally tasks execution post pipelinerun timeout | implementable | 2021-04-14 |
 |[TEP-0047](0047-pipeline-task-display-name.md) | Pipeline Task Display Name | proposed | 2021-02-10 |


### PR DESCRIPTION
Make updates to TEP-0044 to get ready for proposing next steps:
* Add more requirements around hermetic support and status information
* Organize options into "implementation" and "syntax" options which can
  largely be mix and matched - and I think we need to agree on the
  "implementation" (specifically the semantics of this feature)
  before we start focusing on syntax in this case
* Update the "collapse task and pipeline into one thing" option to be a
  bit less theoretical ("foobar" as an example name might have obscured
  the option a bit)
* Add explicit pipeline in a pod and pipeline as a taskrun options
* At this point I think this TEP clearly overlaps with the TEP that was
  previously called TEP-0046 (pipeline in a pod)