### PR TITLE
Add k8s API conventions to design principles ✍️

### DIFF
--- a/design-principles.md
+++ b/design-principles.md
@@ -1,5 +1,9 @@
 # Tekton Design Principles
 
+## API conventions
+1. Changes to Tekton APIs, especially CRD (Custom Resource Definition) based APIs should comply with
+   [Kubernetes API Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#api-conventions).
+
 ## Reusability
 1. Existing features should be reused when possible instead of adding new ones. Before proposing a feature, try solving the problem with existing features first.
 1. Prefer providing a solution in the Catalog when possible to adding a feature.

--- a/teps/tools/tep-template.md.template
+++ b/teps/tools/tep-template.md.template
@@ -229,7 +229,7 @@ expectations).
 
 ## Design Evaluation
 <!--
-How does this proposal affect the reusability, simplicity, flexibility 
+How does this proposal affect the api conventions, reusability, simplicity, flexibility 
 and conformance of Tekton, as described in [design principles](https://github.com/tektoncd/community/blob/master/design-principles.md)
 -->
 


### PR DESCRIPTION
When reviewing a TEP recently I found myself wanting to reference the
k8s design principles (specifically around the convention to prefer
named subobjects to maps https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#lists-of-named-subobjects-preferred-over-maps)
and I was surprised to see this wasn't mentioned in our design
principles or our standards, though my understanding is that we have
been trying to comply with these conventions. (Not to mention I couldn't
remember what to google to find this doc so it's useful to have the link
somewhere we can easily reference XD.)

I'm not sure about making a whole new design principle section, but it
didn't seem like it fit very well into any of the existing sections
(maybe conformance?), and I also thought about adding it to standards.md
but those are really about code changes and by the time code changes are
being made, in most cases API changes would go through a TEP first so I
think it makes sense to evaluate earlier.