### PR TITLE
Add Geri to website maintainers :tada:

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -62,6 +62,7 @@ orgs:
     - frerikandriessen
     - gabemontero
     - garethr
+    - geriom
     - guillaumerose
     - hone
     - houshengbo
@@ -352,6 +353,7 @@ orgs:
         - AlanGreene
         - jjasghar
         - popcor255
+        - geriom
         privacy: closed
         repos:
           website: write


### PR DESCRIPTION
Geri is part of the docs WG and he's focussing on improving our
documentation by:
- setting up a plan for the upcoming website/docs work
- restructuring, improving and consolidating the various getting
  started guides and tutorials
- bringing the version of docsy up-to-date

Thanks Geri for your great work so for and for bringing new life
to our docs working group!

I propose we add Geri as a maintainer to the website (and to the tektoncd org).

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>