### PR TITLE
TEP-0014: Step Timeout - mark as implemented

### DIFF
--- a/teps/0014-step-timeout.md
+++ b/teps/0014-step-timeout.md
@@ -3,8 +3,8 @@ title: Step Timeout
 authors:
   - "@Peaorl"
 creation-date: 2020-09-10
-last-updated: 2020-09-10
-status: implementable
+last-updated: 2021-12-13
+status: implemented
 ---
 
 # TEP-0014: Step timeout

--- a/teps/README.md
+++ b/teps/README.md
@@ -170,7 +170,7 @@ This is the complete list of Tekton teps:
 |[TEP-0010](0010-optional-workspaces.md) | Optional Workspaces | implemented | 2020-10-15 |
 |[TEP-0011](0011-redirecting-step-output-streams.md) | redirecting-step-output-streams | implementable | 2020-11-02 |
 |[TEP-0012](0012-api-spec.md) | API Specification | implementable | 2020-08-10 |
-|[TEP-0014](0014-step-timeout.md) | Step Timeout | implementable | 2020-09-10 |
+|[TEP-0014](0014-step-timeout.md) | Step Timeout | implemented | 2021-12-13 |
 |[TEP-0015](0015-pending-pipeline.md) | pending-pipeline-run | implemented | 2020-09-10 |
 |[TEP-0016](0016-concise-trigger-bindings.md) | Concise Embedded TriggerBindings | implemented | 2020-09-15 |
 |[TEP-0019](0019-other-arch-support.md) | Other Arch Support | proposed | 2020-09-30 |


### PR DESCRIPTION
This was actually done a while back in October 2020 when https://github.com/tektoncd/pipeline/pull/3087 merged.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>