### PR TITLE
TEP-0069: Mark as implemented

### DIFF
--- a/teps/0069-support-retries-for-custom-task-in-a-pipeline.md
+++ b/teps/0069-support-retries-for-custom-task-in-a-pipeline.md
@@ -1,8 +1,8 @@
 ---
-status: implementable
+status: implemented
 title: Support retries for custom task in a pipeline.
 creation-date: '2021-05-31'
-last-updated: '2021-07-26'
+last-updated: '2021-12-15'
 authors:
 - '@Tomcli'
 - '@ScrapCodes'
@@ -215,7 +215,7 @@ An upgrade strategy for existing custom controllers,
 
 ## Implementation Pull request(s)
 
-Not there yet!
+* [tektoncd/pipeline PR #4327 - TEP-69 implemented](https://github.com/tektoncd/pipeline/pull/4327)
 
 ## References (optional)
 

--- a/teps/README.md
+++ b/teps/README.md
@@ -216,7 +216,7 @@ This is the complete list of Tekton teps:
 |[TEP-0063](0063-workspace-dependencies.md) | Workspace Dependencies | proposed | 2021-04-23 |
 |[TEP-0066](0066-dogfooding-tekton.md) | Dogfooding Tekton | proposed | 2021-05-16 |
 |[TEP-0067](0067-tekton-catalog-pipeline-organization.md) | Tekton Catalog Pipeline Organization | implementable | 2021-02-22 |
-|[TEP-0069](0069-support-retries-for-custom-task-in-a-pipeline.md) | Support retries for custom task in a pipeline. | implementable | 2021-07-26 |
+|[TEP-0069](0069-support-retries-for-custom-task-in-a-pipeline.md) | Support retries for custom task in a pipeline. | implemented | 2021-12-15 |
 |[TEP-0070](0070-tekton-catalog-task-platform-support.md) | Platform support in Tekton catalog | proposed | 2021-06-02 |
 |[TEP-0071](0071-custom-task-sdk.md) | Custom Task SDK | proposed | 2021-06-15 |
 |[TEP-0072](0072-results-json-serialized-records.md) | Results: JSON Serialized Records | implementable | 2021-07-26 |


### PR DESCRIPTION
cc @ScrapCodes to verify, but I'm assuming https://github.com/tektoncd/pipeline/pull/4327 being merged means this is done.