### PR TITLE
[TEP-0044] Update Alternatives

### DIFF
--- a/teps/README.md
+++ b/teps/README.md
@@ -196,7 +196,7 @@ This is the complete list of Tekton teps:
 |[TEP-0040](0040-ignore-step-errors.md) | Ignore Step Errors | implemented | 2021-08-11 |
 |[TEP-0041](0041-tekton-component-versioning.md) | Tekton Component Versioning | implementable | 2021-04-26 |
 |[TEP-0042](0042-taskrun-breakpoint-on-failure.md) | taskrun-breakpoint-on-failure | implemented | 2021-12-10 |
-|[TEP-0044](0044-data-locality-and-pod-overhead-in-pipelines.md) | Data Locality and Pod Overhead in Pipelines | proposed | 2022-01-26 |
+|[TEP-0044](0044-data-locality-and-pod-overhead-in-pipelines.md) | Data Locality and Pod Overhead in Pipelines | proposed | 2022-02-02 |
 |[TEP-0045](0045-whenexpressions-in-finally-tasks.md) | WhenExpressions in Finally Tasks | implemented | 2021-06-03 |
 |[TEP-0046](0046-finallytask-execution-post-timeout.md) | Finally tasks execution post pipelinerun timeout | implemented | 2021-12-14 |
 |[TEP-0047](0047-pipeline-task-display-name.md) | Pipeline Task Display Name | proposed | 2021-02-10 |


### PR DESCRIPTION
This commit describes design constraints related to running multiple Tasks in one pod in more detail.
It also updates the alternative solutions based on the clarified problem statement.

Changes:
- Add 3 options: pipeline in a pod + pipelines in pipelines, pipeline -> taskrun, and task pre and post steps
- Modify and add more detail to the "TaskGroup" proposal
- Remove "focus on workspaces" option: this adds new syntax but not new functionality
- Remove "custom pipeline" solution due to similarity with grouping CRD solution
- Remove "custom scheduler" option: This is a solution for scheduling parallel Tasks that share a PVC
  on the same node, but does not address the problems of pod overhead and the need
  to share data between tasks in the first place.

Co-authored-by: Christie Wilson christiewilson@google.com @bobcatfish 

/kind tep
/assign vdemeester
/assign afrittoli