### PR TITLE
Add sbwsg as collaborator in plumbing

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -547,6 +547,7 @@ orgs:
         - SM43
         - bobcatfish
         - afrittoli
+        - sbwsg
         privacy: closed
         repos:
           plumbing: read


### PR DESCRIPTION
I over-removed myself from even having lgtm in plumbing which doesn't make sense, oops!

Re-adding myself so I can collab on plumbing PRs, deliver reviews and provide lgtms.