### PR TITLE
Temporary add sbwsg as pipelines owner for 0.32

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -215,6 +215,7 @@ orgs:
         - dlorenc
         - dibyom
         - jerop
+        - sbwsg
         privacy: closed
         repos:
           pipeline: write


### PR DESCRIPTION
I removed myself a while ago as a maintainer from tekton pipelines but
am currently the release captain for Pipelines 0.32. Unfortunately being
a maintainer is required to edit a Release or push branches, both of
which are required during a release rotation.

This commit re-adds me as a maintainer on tekton pipelines with the
intention of removing myself again once the 0.32 release window is
passed. Sorry for the churn!