### PR TITLE
Add link to gov board meeting at top of page 🔗

### DIFF
--- a/working-groups.md
+++ b/working-groups.md
@@ -39,6 +39,7 @@ The current working groups are:
 - [Chains](#chains)
 - [Workflows](#workflows)
 - [Pipeline](#pipeline)
+- [Governing board / Community](#governing-board--community)
 
 ## General
 


### PR DESCRIPTION
Forgot to add this when I added the governing board/community
meeting in https://github.com/tektoncd/community/pull/578 !