### PR TITLE
Add resolution repo to org.yaml

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -724,3 +724,17 @@ orgs:
         members:
         - afrittoli
         privacy: closed
+      resolution.maintainers:
+        description: The resolution maintainers
+        maintainers:
+        - abayer
+        - afrittoli
+        - bobcatfish
+        - dibyom
+        - vdemeester
+        members:
+        - sbwsg
+        - dibyom
+        privacy: closed
+        repos:
+          resolution: write


### PR DESCRIPTION
The resolution repo has just been spun up to host everything related to remote resolution in tekton.

This PR initializes the org.yaml entries for the resolution project, adding two teams: maintainers and collaborators.

Fixes https://github.com/tektoncd/community/issues/611