### PR TITLE
Fix TEP Linting

### DIFF
--- a/teps/README.md
+++ b/teps/README.md
@@ -230,7 +230,7 @@ This is the complete list of Tekton teps:
 |[TEP-0084](0084-endtoend-provenance-collection.md) | end-to-end provenance collection | proposed | 2021-09-16 |
 |[TEP-0085](0085-per-namespace-controller-configuration.md) | Per-Namespace Controller Configuration | proposed | 2021-10-14 |
 |[TEP-0088](0088-result-summaries.md) | Tekton Results - Record Summaries | proposed | 2021-10-01 |
-|[TEP-0089](0089-nonfalsifiable-provenance-support.md) | Non-falsifiable provenance support | proposed | 2021-11-18 |
+|[TEP-0089](0089-nonfalsifiable-provenance-support.md) | Non-falsifiable provenance support | proposed | 2022-01-18 |
 |[TEP-0090](0090-matrix.md) | Matrix | proposed | 2021-11-08 |
 |[TEP-0094](0094-configuring-resources-at-runtime.md) | Configuring Resources at Runtime | implementable | 2021-11-29 |
 |[TEP-0096](0096-pipelines-v1-api.md) | Pipelines V1 API | proposed | 2021-12-13 |


### PR DESCRIPTION
This change fixes the date on TEP-0089 to pass the PipelineRun on open TEPs (which is failing and blocking all PRs in this repo).

The `pull-community-teps-lint` PipelineRun did not run when we merged TEP-0089 in https://github.com/tektoncd/community/pull/529. It got merged with a linting issue - wrong date - that's causing the same PipelineRun to fail in open TEPs. Why it didn't run in that PR is still a mystery but focusing on unblocking PRs for now.

Examples: 
- https://dashboard.dogfooding.tekton.dev/#/namespaces/tekton-ci/pipelineruns/pull-community-teps-lint-h6fwd?pipelineTask=teps-lint&step=teps-table
- https://dashboard.dogfooding.tekton.dev/#/namespaces/tekton-ci/pipelineruns/pull-community-teps-lint-vw6qj?pipelineTask=teps-lint&step=teps-table