### PR TITLE
Add @vinamra28 as Hub Maintainer

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -264,6 +264,7 @@ orgs:
         - pratap0007
         - PuneetPunamiya
         - SM43
+        - vinamra28
         privacy: closed
         repos:
           hub: write


### PR DESCRIPTION
Based on PR https://github.com/tektoncd/hub/pull/365, I want to add
myself as Hub maintainer. Link to my contributions are:

https://tekton.devstats.cd.foundation/d/9/developer-activity-counts-by-repository-group-table?orgId=1&var-period_name=Last%20year&var-metric=contributions&var-repogroup_name=tektoncd%2Fhub&var-country_name=All

Signed-off-by: vinamra28 <vinjain@redhat.com>