### PR TITLE
Update Chains facilitator rotation

### DIFF
--- a/working-groups.md
+++ b/working-groups.md
@@ -314,12 +314,12 @@ This is the working group for [`tektoncd/chains`](https://github.com/tektoncd/ch
 | Meeting Notes              | [Notes](https://docs.google.com/document/d/1UVPSCDyNO-TzEFSv8jrqrEOF_FmV8NFuXncFm1gwmeY/edit) |
 | Slack Channels             | [#chains](https://tektoncd.slack.com/messages/chains) |
 
-| &nbsp;                                                         | Facilitators    | Company | Profile                                           |
-| -----------------------------------------------------------    | ----------      | ------- | ------------------------------------------------  |
-| <img width="30px" src="https://github.com/dlorenc.png">        | Dan Lorenc      | Google  | [dlorenc](https://github.com/dlorenc) |
-| <img width="30px" src="https://github.com/priyawadhwa.png">    | Priya Wadhwa    | Google  | [priyawadhwa](https://github.com/priyawadhwa)     |
-| <img width="30px" src="https://github.com/pritidesai.png">     | Priti Desai     | IBM     | [pritidesai](https://github.com/pritidesai) |
-| <img width="30px" src="https://github.com/bobcatfish.png">     | Christie Wilson | Google  | [bobcatfish](https://github.com/bobcatfish) |
+| &nbsp;                                                         | Facilitators    | Company    | Profile                                           |
+| -----------------------------------------------------------    | ----------      | ---------- | ------------------------------------------------  |
+| <img width="30px" src="https://github.com/priyawadhwa.png">    | Priya Wadhwa    | Chainguard | [priyawadhwa](https://github.com/priyawadhwa)     |
+| <img width="30px" src="https://github.com/pritidesai.png">     | Priti Desai     | IBM        | [pritidesai](https://github.com/pritidesai) |
+| <img width="30px" src="https://github.com/bobcatfish.png">     | Christie Wilson | Google     | [bobcatfish](https://github.com/bobcatfish) |
+| <img width="30px" src="https://github.com/wlynch.png">         | Billy Lynch     | Google     | [wlynch](https://github.com/wlynch) |
 
 ## Workflows
 


### PR DESCRIPTION
In the working group today, @wlynch volunteered to join the Chains
rotation. @dlorenc is listed in the rotation, I think from when the
working group was initially set up but hasn't been in the meeting
rotation.

(@dlorenc if you do want to be in the rotation after all just let me know and I'll change the commit!)

Also updated @priyawadhwa 's company! Exciting :D