### PR TITLE
Remove Dibyo from members list of resolution.maintainers

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -736,7 +736,6 @@ orgs:
         - vdemeester
         members:
         - sbwsg
-        - dibyom
         privacy: closed
         repos:
           resolution: write


### PR DESCRIPTION
In my previous PR for the resolution.maintainers team peribolos was
erroring out during dry-run of team creation. This meant I missed a
lint error that would have otherwise surfaced.

This commit removes Dibyo from the members list of the
resolution.maintainers team since he already appears in the
"maintainers" list for that same team.