### PR TITLE
TEP-0025: API change - use string alias instead of bool

### DIFF
--- a/teps/0025-hermekton.md
+++ b/teps/0025-hermekton.md
@@ -30,6 +30,8 @@ status: implementable
 - [Alternatives](#alternatives)
   - [Entire Pod Sandboxing](#entire-pod-sandboxing)
   - [Don't Use Pipelines Directly](#dont-use-pipelines-directly)
+  - [Pre/Post-Steps](#prepost-steps)
+  - [Network-Jail &quot;fences&quot;](#network-jail-fences)
 - [Infrastructure Needed (optional)](#infrastructure-needed-optional)
 - [Upgrade &amp; Migration Strategy (optional)](#upgrade--migration-strategy-optional)
 - [References (optional)](#references-optional)
@@ -80,8 +82,15 @@ Tekton Pipelines will add support for a new "ExecutionMode" field on several obj
 That type will look like:
 
 ```go
+type HermeticMode string
+
+const (
+    NetworkingOff   HermeticMode = "disabled"
+    NetworkingOn    HermeticMode = "enabled"
+)
+
 type ExecutionMode struct {
-	Hermetic bool
+	Hermetic HermeticMode `json:"hermetic,omitempty"`
 }
 ```
 


### PR DESCRIPTION
Today, hermetic execution is supported through annotations as an
experiment. If successful, we plan to support hermetic execution
through a field in the API. The proposed API uses a bool, however
the Kubernetes API conventions [discourage using booleans][bools]
because they limit future expansions. This change updates the field
to use a string alias instead, as recommended in the conventions.

/kind tep

https://github.com/tektoncd/community/blob/main/teps/0025-hermekton.md

[bools]: https://github.com/kubernetes/community/blob/fbc5ca53d6bfd8388b335f7d0198b67a14b99d91/contributors/devel/sig-architecture/api-conventions.md#primitive-types