### PR TITLE
[TEP-0096]: V1 plan for ClusterTask

### DIFF
--- a/teps/0096-pipelines-v1-api.md
+++ b/teps/0096-pipelines-v1-api.md
@@ -2,7 +2,7 @@
 status: proposed
 title: Pipelines V1 API
 creation-date: '2021-11-29'
-last-updated: '2021-12-20'
+last-updated: '2021-02-07'
 authors:
 - '@lbernick'
 - '@jerop'
@@ -219,7 +219,8 @@ This policy should be updated to include Tekton metrics as part of the API. No o
 - Keep the ClusterTask CRD at beta stability.
   - ClusterTask functionality will likely be replaced by [remote resolution](./0060-remote-resource-resolution.md), but there's no plan
   to replace this functionality at a beta level of stability before releasing a V1 API.
-  - [Still under discussion]: We will decide before v1 whether to stabilize or remove ClusterTask pending community feedback on ClusterTask and remote resolution.
+  - For the V1 API, ClusterTask should continue to be supported but left at beta stability. After implementing and receiving
+  user feedback on remote resolution, we can make a decision about whether to deprecate ClusterTask or bring it to stable.
   See [Where should we take ClusterTasks next?](https://github.com/tektoncd/pipeline/issues/4476) for more info.
 
 | CRD         | Current level | Proposed level |

--- a/teps/README.md
+++ b/teps/README.md
@@ -233,6 +233,6 @@ This is the complete list of Tekton teps:
 |[TEP-0089](0089-nonfalsifiable-provenance-support.md) | Non-falsifiable provenance support | proposed | 2022-01-18 |
 |[TEP-0090](0090-matrix.md) | Matrix | proposed | 2021-11-08 |
 |[TEP-0094](0094-configuring-resources-at-runtime.md) | Configuring Resources at Runtime | implementable | 2021-11-29 |
-|[TEP-0096](0096-pipelines-v1-api.md) | Pipelines V1 API | proposed | 2021-12-20 |
+|[TEP-0096](0096-pipelines-v1-api.md) | Pipelines V1 API | proposed | 2021-02-07 |
 |[TEP-0098](0098-workflows.md) | Workflows | proposed | 2021-12-06 |
 |[TEP-0100](0100-embedded-taskruns-and-runs-status-in-pipelineruns.md) | Embedded TaskRuns and Runs Status in PipelineRuns | proposed | 2022-01-29 |


### PR DESCRIPTION
This commit updates our v1 plan to recommend leaving ClusterTask in beta.
We haven't received any user feedback (on tektoncd/pipeline#4476) indicating that ClusterTasks meet a use case that
isn't met with remote resolution. We should wait to see how remote resolution works for users
before deciding to increase stability guarantees for ClusterTask.

/kind tep