### PR TITLE
[TEP-0044]: Controller role in scheduling TaskRuns

### DIFF
--- a/teps/README.md
+++ b/teps/README.md
@@ -196,7 +196,7 @@ This is the complete list of Tekton teps:
 |[TEP-0040](0040-ignore-step-errors.md) | Ignore Step Errors | implemented | 2021-08-11 |
 |[TEP-0041](0041-tekton-component-versioning.md) | Tekton Component Versioning | implementable | 2021-04-26 |
 |[TEP-0042](0042-taskrun-breakpoint-on-failure.md) | taskrun-breakpoint-on-failure | implemented | 2021-12-10 |
-|[TEP-0044](0044-data-locality-and-pod-overhead-in-pipelines.md) | Data Locality and Pod Overhead in Pipelines | proposed | 2022-02-07 |
+|[TEP-0044](0044-data-locality-and-pod-overhead-in-pipelines.md) | Data Locality and Pod Overhead in Pipelines | proposed | 2022-02-09 |
 |[TEP-0045](0045-whenexpressions-in-finally-tasks.md) | WhenExpressions in Finally Tasks | implemented | 2021-06-03 |
 |[TEP-0046](0046-finallytask-execution-post-timeout.md) | Finally tasks execution post pipelinerun timeout | implemented | 2021-12-14 |
 |[TEP-0047](0047-pipeline-task-display-name.md) | Pipeline Task Display Name | proposed | 2021-02-10 |


### PR DESCRIPTION
This commit addresses the question of whether Tekton should be responsible for determining
which TaskRuns are executed in one pod. It proposes leaving this functionality as an option
for a later iteration of the proposal, and modifies the "TaskGroup" proposal to specify
that for the first implementation, all TaskRuns in a TaskGroup should be run in one pod.

/kind tep