### PR TITLE
Give back temp maintainer status now that 0.32 is released

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -216,7 +216,6 @@ orgs:
         - dlorenc
         - dibyom
         - jerop
-        - sbwsg
         privacy: closed
         repos:
           pipeline: write


### PR DESCRIPTION
In https://github.com/tektoncd/community/pull/605 I temporarily
requested maintainer status on pipelines so I could perform the releases
of Pipelines 0.32 + patches.

Now that the 0.32 release cycle is done this PR gives back that temp
maintainer status. Cheers & sorry again for the churn!