### PR TITLE
Update details of docs working group

### DIFF
--- a/working-groups.md
+++ b/working-groups.md
@@ -136,8 +136,8 @@ Connecting to the Meeting VC requires a Zoom account.
 | -------------------------- | -------------------------- |
 | Forum                      | [tekton-dev@](https://groups.google.com/forum/#!forum/tekton-dev) |
 | Community Meeting VC       | [https://zoom.us/j/97950473778?pwd=MWk5TUFZYWxkRzhOcThFV3NMbXBXQT09](https://zoom.us/j/97950473778?pwd=MWk5TUFZYWxkRzhOcThFV3NMbXBXQT09) |
-| Community Meeting Calendar | Wednesdays every week, 11:00a-11:30a EST <br>[Calendar](https://calendar.google.com/event?action=TEMPLATE&tmeid=MW9oZzNpbmkxbHU5ZGtlN2hnMzVsYjNpcTJfMjAyMDAxMjlUMTgwMDAwWiBnb29nbGUuY29tX2Qzb3Zjdm8xcDMyMTloOTg5NTczdjk4Zm5zQGc&tmsrc=google.com_d3ovcvo1p3219h989573v98fns%40group.calendar.google.com&scp=ALL) |
-| Meeting Notes              | [Notes](https://www.google.com/url?q=https://docs.google.com/document/d/1nnJe4rWBFZORW9ScV9o-yk6BmvX419DDKKwIlORRhsY/edit%23&sa=D&ust=1575716141397000&usg=AOvVaw0IMqtfI1KeX8a6zq2ODl9n) |
+| Community Meeting Calendar | Tuesdays every week, 1:00pm-1:30pm EST <br>[Calendar](https://calendar.google.com/event?action=TEMPLATE&tmeid=NnNuNnViZjd2YmdvNnVmcWk2ZGFrZDJuY21fMjAyMjAyMjJUMTgwMDAwWiBnb29nbGUuY29tX2Qzb3Zjdm8xcDMyMTloOTg5NTczdjk4Zm5zQGc&tmsrc=google.com_d3ovcvo1p3219h989573v98fns%40group.calendar.google.com&scp=ALL) |
+| Meeting Notes              | [Notes](https://docs.google.com/document/d/1nnJe4rWBFZORW9ScV9o-yk6BmvX419DDKKwIlORRhsY/edit) |
 | Document Folder            | [Folder](https://drive.google.com/drive/folders/1dpGatrFh_Wykrs_tUkVK8hLNF1VaGHZd) |
 | Slack Channel              | [#docs](https://tektoncd.slack.com/messages/docs) |
 
@@ -145,9 +145,8 @@ Connecting to the Meeting VC requires a Zoom account.
 | &nbsp;                                                     | Facilitators     | Company | Profile                                     |
 | --------------------------------------------------------   | ----------       | ------- | ---------------------------------------     |
 | <img width="30px" src="https://github.com/afrittoli.png">  | Andrea Frittoli  | IBM     | [afrittoli](https://github.com/afritolli)   |
-| <img width="30px" src="https://github.com/anneqm.png">     | Anne Michalak    | IBM     | [anneqm](https://github.com/anneqm)         |
-| <img width="30px" src="https://github.com/popcor255.png">  | Napoleon Santana | IBM     | [popcor255](https://github.com/popcor255)   |
 | <img width="30px" src="https://github.com/AlanGreene.png"> | Alan Greene      | IBM     | [AlanGreene](https://github.com/AlanGreene) |
+| <img width="30px" src="https://github.com/geriom.png">     | Geri Ochoa       | Google  | [geriom](https://github.com/geriom)         |
 
 ## Productivity
 


### PR DESCRIPTION
Details for the docs working group are out of date, meaning
some folks miss the meeting or wait to join the old one on
the wrong day.

- Update time/date
- Add correct calendar link
- Update list of faciliators
- Link to correct doc for 2022