### PR TITLE
Fix link to contributor ladder from main README 🔗

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Find out about our processes:
 
 - [Find something to work on](process.md#finding-something-to-work-on)
 - [Propose features](process.md#proposing-features)
-- [Project OWNERS](process.md#OWNERS)
+- [Contributor ladder](process.md#contributor-ladder)
 - [Pull request reviews](process.md#reviews)
 - [Propose projects](process.md#proposing-projects)
 - [GitHub Org Management](org/README.md), including


### PR DESCRIPTION
In https://github.com/tektoncd/community/pull/549 we updated the contributor ladder but missed this link