### PR TITLE
[TEP-0100] Update to handle PipelineTask condition checks and when expressions

### DIFF
--- a/teps/README.md
+++ b/teps/README.md
@@ -238,4 +238,4 @@ This is the complete list of Tekton teps:
 |[TEP-0095](0095-common-repository-configuration.md) | Common Repository Configuration | proposed | 2021-11-29 |
 |[TEP-0096](0096-pipelines-v1-api.md) | Pipelines V1 API | implementable | 2022-03-18 |
 |[TEP-0098](0098-workflows.md) | Workflows | proposed | 2021-12-06 |
-|[TEP-0100](0100-embedded-taskruns-and-runs-status-in-pipelineruns.md) | Embedded TaskRuns and Runs Status in PipelineRuns | implementable | 2022-02-14 |
+|[TEP-0100](0100-embedded-taskruns-and-runs-status-in-pipelineruns.md) | Embedded TaskRuns and Runs Status in PipelineRuns | implementing | 2022-03-23 |


### PR DESCRIPTION
With the current, full embedded status for `TaskRun`s and `Run`s, we include `ConditionChecks` and `WhenExpressions` fields as well as the `TaskRun`/`Run`'s status. The minimal embedded status approach as initially written does fine for anything that's available within the `TaskRun`/`Run` statuses, but `ConditionChecks` and `WhenExpressions` are not actually known by the `TaskRun`/`Run`. They're only known at the full `PipelineRun` level. In order to make that information available for reporting, etc in the new minimal embedded status approach, we will need to store `ConditionChecks` and `WhenExpressions` along with the kind/version/`TaskRun` or `Run` name/`PipelineTask` name.

cc @jerop @lbernick - not sure who else should review this?

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>