### PR TITLE
Update the experimental maintainers

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -236,12 +236,13 @@ orgs:
         maintainers:
         - abayer
         - bobcatfish
-        - mnuttall
         members:
         - skaegi
         - dlorenc
-        - a-roberts
-        - dibbles
+        - afrittoli
+        - vdemeester
+        - dibyom
+        - priyawadhwa
         privacy: closed
         repos:
           experimental: write


### PR DESCRIPTION
Cleanup the experimental.maintainers team. Remove inactive users
and add the tekton governance team

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>