### PR TITLE
Experiment with removing team maintainers

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -163,14 +163,13 @@ orgs:
         privacy: closed
       catalog.maintainers:
         description: the catalog maintainers
-        maintainers:
-        - vdemeester
-        - ImJasonH
-        - bobcatfish
         members:
-        - kimsterv
-        - dlorenc
+        - bobcatfish
         - chmouel
+        - dlorenc
+        - ImJasonH
+        - kimsterv
+        - vdemeester
         - vinamra28
         privacy: closed
         repos:


### PR DESCRIPTION
GitHub let us define a list of team members and team maintainers.
Since we maintain teams through peribolos, we should not really
have a list of team maintainers.

Each repo has a <repo>.maintainers and a <repo>.<collaborators>
team, each with its own list of maintainers and members, which
make things notably more confusing.

Last and not least, we have a pending task of sync'ing teams to
OWNER files in repos, however today it's hard to be sure that
the list of people members of <repo>.maintainers teams are those
who need to be in OWNERS since each individual can only be a
maintainer or a member.

Start experimenting doing this for the catalog team.

This also means that the Tekton governance team members do not
need to be members of all teams and maintainers of all repos.

It might be handy though to have one that can approve and merge
a PR in case of lock or urgent / security issues, but we can still achieve
that by giving write access to all repo to the governance team.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>