### PR TITLE
[TEP-0075, 0076] Make array and object support implementable 👷‍♀️

### DIFF
--- a/teps/0075-object-param-and-result-types.md
+++ b/teps/0075-object-param-and-result-types.md
@@ -1,8 +1,8 @@
 ---
-status: proposed
+status: implementable
 title: Object/Dictionary param and result types
 creation-date: '2021-07-14'
-last-updated: '2022-02-02'
+last-updated: '2022-03-18'
 authors:
 - '@bobcatfish'
 - '@skaegi' # I didn't check with @skaegi before adding his name here, but I wanted to credit him b/c he proposed most of this in https://github.com/tektoncd/pipeline/issues/1393 1.5 years ago XD
@@ -421,6 +421,9 @@ Declaring defaults for parameters that are of type object would follow the patte
 [array param defaults](https://github.com/tektoncd/pipeline/blob/main/docs/tasks.md#specifying-parameters) which is
 to declare the value in the expected format in yaml (which is treated as json by the k8s APIs).
 
+If a value is provided for the param, the default will not be used (i.e. there will be no behavior to merge the
+default with the provided value, if for example the provided value specified some fields but not others).
+
 Params example with default value:
 
 ```yaml
@@ -595,10 +598,12 @@ In the above example:
 cat /place/with/actual/cloned/gitrepo.json > $(results.cloned-gitrepo.path)
 ```
 
-`$(results.cloned-gitrepo.path)` refers to the path at which to write the `clone-gitrepo` object as json (tt does not
+`$(results.cloned-gitrepo.path)` refers to the path at which to write the `clone-gitrepo` object as json (it does not
 refer to an attribute of `cloned-gitrepo` called `path`, and even if `cloned-gitrepo` had a `path` attribute, there
 would be no collision because variable replacement for individual attributes of the result is not supported within the
 Task.
+
+(See [emitting object reesults](#emitting-object-results) for more details.)
 
 #### Within a Pipeline Task
 

--- a/teps/0076-array-result-types.md
+++ b/teps/0076-array-result-types.md
@@ -1,8 +1,8 @@
 ---
-status: proposed
+status: implementable
 title: Array result types
 creation-date: '2021-07-14'
-last-updated: '2022-02-03'
+last-updated: '2022-03-18'
 authors:
 - '@bobcatfish'
 ---

--- a/teps/README.md
+++ b/teps/README.md
@@ -222,7 +222,7 @@ This is the complete list of Tekton teps:
 |[TEP-0072](0072-results-json-serialized-records.md) | Results: JSON Serialized Records | implementable | 2021-07-26 |
 |[TEP-0073](0073-simplify-metrics.md) | Simplify metrics | implemented | 2022-02-28 |
 |[TEP-0074](0074-deprecate-pipelineresources.md) | Deprecate PipelineResources | proposed | 2022-02-25 |
-|[TEP-0075](0075-object-param-and-result-types.md) | Object/Dictionary param and result types | implementable | 2022-03-18 |
+|[TEP-0075](0075-object-param-and-result-types.md) | Object/Dictionary param and result types | implementable | 2022-04-08 |
 |[TEP-0076](0076-array-result-types.md) | Array result types | implementable | 2022-03-18 |
 |[TEP-0079](0079-tekton-catalog-support-tiers.md) | Tekton Catalog Support Tiers | proposed | 2022-01-25 |
 |[TEP-0080](0080-support-domainscoped-parameterresult-names.md) | Support domain-scoped parameter/result names | implemented | 2021-08-19 |

--- a/teps/README.md
+++ b/teps/README.md
@@ -222,8 +222,8 @@ This is the complete list of Tekton teps:
 |[TEP-0072](0072-results-json-serialized-records.md) | Results: JSON Serialized Records | implementable | 2021-07-26 |
 |[TEP-0073](0073-simplify-metrics.md) | Simplify metrics | implemented | 2022-02-28 |
 |[TEP-0074](0074-deprecate-pipelineresources.md) | Deprecate PipelineResources | proposed | 2022-02-25 |
-|[TEP-0075](0075-object-param-and-result-types.md) | Object/Dictionary param and result types | proposed | 2022-02-02 |
-|[TEP-0076](0076-array-result-types.md) | Array result types | proposed | 2022-02-03 |
+|[TEP-0075](0075-object-param-and-result-types.md) | Object/Dictionary param and result types | implementable | 2022-03-18 |
+|[TEP-0076](0076-array-result-types.md) | Array result types | implementable | 2022-03-18 |
 |[TEP-0079](0079-tekton-catalog-support-tiers.md) | Tekton Catalog Support Tiers | proposed | 2022-01-25 |
 |[TEP-0080](0080-support-domainscoped-parameterresult-names.md) | Support domain-scoped parameter/result names | implemented | 2021-08-19 |
 |[TEP-0081](0081-add-chains-subcommand-to-the-cli.md) | Add Chains sub-command to the CLI | implementable | 2021-10-21 |


### PR DESCRIPTION
Update the TEPs about array and object support (TEP-0075 and TEP-0076)
to be implementable.

Also addressing feedback from @afrittoli in https://github.com/tektoncd/community/pull/479

Outstanding items:

* @afrittoli re. behavior of optional fields when combined with variable replacement (https://github.com/tektoncd/community/pull/479#discussion_r802555575) - i think that attempts to do variable replacement with a value that is not provided (even if it is optional) should fail and we should lean on the ability to provide defaults (and esp [TEP-0048](https://github.com/tektoncd/community/blob/main/teps/0048-task-results-without-results.md)) instead
* @afrittoli re. supporting a mode with no schema provided at all ((https://github.com/tektoncd/community/pull/479#discussion_r802634562, https://github.com/tektoncd/community/pull/479#discussion_r802646154) - can you provide an example of what that would look like? (also feels like maybe a future enhancement we could add?)
* @mogsie please raise if your concerns from https://github.com/tektoncd/community/pull/477 were not addressed

cc @wlynch 
