### PR TITLE
Create a community.maintainers team

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -436,6 +436,19 @@ orgs:
         privacy: closed
         repos:
           website: read
+      community.maintainers:
+        description: The community maintainers, Tekton GB and others
+        members:
+        - bobcatfish
+        - jerop
+        - vdemeester
+        - dibyom
+        - priyawadhwa
+        - afrittoli
+        - pritidesai
+        privacy: closed
+        repos:
+          community: write
       community.collaborators:
         description: The community collaborators
         maintainers:


### PR DESCRIPTION
Community didn't have a team until now as we identified the
maintainers team with the Tekton governance team. The teams
may actually diverge, the first case is adding Priti :tada:
to the community maintainers to enable her to add commits
to an existing PR.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>