### PR TITLE
Added the security policy to the contact page

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -30,6 +30,8 @@ group, so please join if you are interested in accessing those docs.
 Our mailing list for end users of Tekton is
 [tekton-users@](https://groups.google.com/forum/#!forum/tekton-users).
 
+To report or enquiry about security issues, please refer to our [security policy](https://github.com/tektoncd/community/security/policy).
+
 ## Calendar
 
 Tekton events such as [working group](./working-groups.md) and other meetings


### PR DESCRIPTION
The contact.md page includes details on how to reach out to the Tekton
community. It should include details about reporting security related
issues as well.