### PR TITLE
Add jerop and priya to governing board, remove andrew 🗝️

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,6 +3,7 @@
 approvers:
 - bobcatfish
 - vdemeester
-- abayer
 - afrittoli
 - dibyom
+- priyawadhwa
+- jerop

--- a/governance.md
+++ b/governance.md
@@ -21,13 +21,19 @@ one year: every year either two or three of the seats are up for election.
 
 ### Current members
 
+| Full Name                                  |  Company   | GitHub                                        | Slack                                                         | Elected On | Until    |
+|-------------------                         |:----------:|-----------------------------------------------|---------------------------------------------------------------|------------|----------|
+| Priya Wadhwa                               | ChainGuard | [priyawadhwa](https://github.com/priyawadhwa) | [@Priya Wadhwa](https://tektoncd.slack.com/team/U02T0CS9PN0)  | Feb 2022   | Feb 2024 |
+| Vincent Deemester                          |  Red Hat   | [vdemeester](https://github.com/vdemeester)   | [@vdemeester](https://tektoncd.slack.com/team/UHSQGV1L3)      | Feb 2021   | Feb 2023 |
+| Jerop Kipruto (while Christie is on leave) |   Google   | [jerop](https://github.com/jerop)             | [@Jerop Kipruto](https://tektoncd.slack.com/team/U011DPQSP0V) | Apr 2022   | Oct 2022 |
+| Andrea Frittoli                            |    IBM     | [afrittoli](https://github.com/afrittoli)     | [@Andrea Frittoli](https://tektoncd.slack.com/team/UJ411P2CC) | Feb 2022   | Feb 2024 |
+| Dibyo Mukherjee                            |   Google   | [dibyom](https://github.com/dibyom)           | [@Dibyo Mukherjee](https://tektoncd.slack.com/team/UJ73HM7PZ) | Feb 2021   | Feb 2023 |
+
+On leave until Oct 3, 2022:
+
 | Full Name         |  Company   | GitHub                                        | Slack                                                         | Elected On | Until    |
 |-------------------|:----------:|-----------------------------------------------|---------------------------------------------------------------|------------|----------|
-| Priya Wadhwa      | ChainGuard | [priyawadhwa](https://github.com/priyawadhwa) | [@Priya Wadhwa](https://tektoncd.slack.com/team/U02T0CS9PN0)  | Feb 2022   | Feb 2024 |
-| Vincent Deemester |  Red Hat   | [vdemeester](https://github.com/vdemeester)   | [@vdemeester](https://tektoncd.slack.com/team/UHSQGV1L3)      | Feb 2021   | Feb 2023 |
 | Christie Wilson   |   Google   | [bobcatfish](https://github.com/bobcatfish)   | [@Christie Wilson](https://tektoncd.slack.com/team/UJ6DECY78) | Feb 2021   | Feb 2023 |
-| Andrea Frittoli   |    IBM     | [afrittoli](https://github.com/afrittoli)     | [@Andrea Frittoli](https://tektoncd.slack.com/team/UJ411P2CC) | Feb 2022   | Feb 2024 |
-| Dibyo Mukherjee   |   Google   | [dibyom](https://github.com/dibyom)           | [@Dibyo Mukherjee](https://tektoncd.slack.com/team/UJ73HM7PZ) | Feb 2021   | Feb 2023 |
 
 There is no designated facilitator at the moment, the responsibility is
 distributed across the five members of the committee.
@@ -253,15 +259,17 @@ Note that we have constrained the board such that no single employer can have mo
 
 When someone joins the governing board:
 
+- They should be added to [the list of current governing board members](#current-members)
 - They should be granted
   [the permissions given them as members of the governing board](#permissions-and-access)
 - They will be added to the `#governance-private` and `#governance`
   [slack](contact.md#slack) channels
-- They will be added to the "Tekton Governing Board Meeting" which occurs every
-  2 weeks and to the facilitator rotation, and added to the document as owners
+- They will be added as facilitators to [the Governing Board and Community meeting](https://github.com/tektoncd/community/blob/main/working-groups.md#governing-board--community)
 - They will be added as managers to
   [the Tekton community Google Drive](https://github.com/tektoncd/community/blob/main/contact.md#shared-drive)
 - They will be added as admins to
+  [the tektoncd GitHub org](https://github.com/tektoncd/community/blob/main/org/org.yaml)
+- They will be added as team members to the `governing-board` team in
   [the tektoncd GitHub org](https://github.com/tektoncd/community/blob/main/org/org.yaml)
 - They will be added as owners to
   [the community repo](https://github.com/tektoncd/community/blob/main/OWNERS)
@@ -274,16 +282,19 @@ When someone joins the governing board:
 
 When someone leaves the governing board:
 
+- They should be moved from [the list of current governing board members](#current-members) to [the list of former members](#former-members-%EF%B8%8F)
 - [The permissions given them as members of the governing board](#permissions-and-access)
   should be revoked, unless they need them to continue to
-  [act as build cop](https://github.com/tektoncd/plumbing/tree/main/bots/buildcaptain#tekton-buildcaptain)
-- They will be removed from the "Tekton Governing Board Meeting" and removed as
-  editors from the agenda doc
+  [act as build captain](https://github.com/tektoncd/plumbing/tree/main/bots/buildcaptain#tekton-buildcaptain)
+- They may want to be removed as facilitators to [the Governing Board and Community meeting](https://github.com/tektoncd/community/blob/main/working-groups.md#governing-board--community)
+  (ask them their preference) - they are welcome to continue
 - They will be removed from the `#governance-private` [slack](contact.md#slack)
   channel
 - They will be removed as managers from
   [the Tekton community Google Drive](https://github.com/tektoncd/community/blob/main/contact.md#shared-drive)
 - They will be removed as admins from
+  [the tektoncd GitHub org](https://github.com/tektoncd/community/blob/main/org/org.yaml)
+- They will be removed as team members to the `governing-board` team in
   [the tektoncd GitHub org](https://github.com/tektoncd/community/blob/main/org/org.yaml)
 - They will be removed as owners from
   [the community repo](https://github.com/tektoncd/community/blob/main/OWNERS)

--- a/org/org.yaml
+++ b/org/org.yaml
@@ -8,6 +8,7 @@ orgs:
     - vdemeester
     - afrittoli
     - dibyom
+    - jerop
     billing_email: info@cd.foundation
     company: ''
     default_repository_permission: none
@@ -73,7 +74,6 @@ orgs:
     - hrishin
     - iancoffey
     - ispasov
-    - jerop
     - jessm12
     - jinchihe
     - jjasghar
@@ -162,6 +162,7 @@ orgs:
         - vdemeester
         - afrittoli
         - dibyom
+        - jerop
         privacy: closed
       catalog.maintainers:
         description: the catalog maintainers

--- a/working-groups.md
+++ b/working-groups.md
@@ -378,13 +378,16 @@ and a place to discuss community operations and process.
 | Community Meeting Calendar | Tuesday every other week, 09:00a-09:30a PST <br>[Calendar](https://calendar.google.com/event?action=TEMPLATE&tmeid=NjFvcHNib2E2cjNwcGc2dGhnMmY2OGU4YTFfMjAyMjAxMThUMTcwMDAwWiBnb29nbGUuY29tX2Qzb3Zjdm8xcDMyMTloOTg5NTczdjk4Zm5zQGc&tmsrc=google.com_d3ovcvo1p3219h989573v98fns%40group.calendar.google.com&scp=ALL) |
 
 
-| &nbsp;                                                     | Facilitators      | Company   | Profile                                     |
-| --------------------------------------------------------   | ----------        | -------   | ---------------------------------------     |
-| <img width="30px" src="https://github.com/abayer.png">     | Andrew Bayer      | CloudBees | [abayer](https://github.com/abayer) |
-| <img width="30px" src="https://github.com/afrittoli.png">  | Andrea Frittoli   | IBM       | [afrittoli](https://github.com/afrittoli)   |
-| <img width="30px" src="https://github.com/bobcatfish.png"> | Christie Wilson   | Google    | [bobcatfish](https://github.com/bobcatfish) |
-| <img width="30px" src="https://github.com/dibyom.png">     | Dibyo Mukherjee   | Google    | [dibyom](https://github.com/dibyom)         |
-| <img width="30px" src="https://github.com/vdemeester.png"> | Vincent Demeester | Red Hat   | [vdemeester](https://github.com/vdemeester) |
+| &nbsp;                                                      | Facilitators      | Company    | Profile                                      |
+| --------------------------------------------------------    | ----------        | -------    | ---------------------------------------      |
+| <img width="30px" src="https://github.com/abayer.png">      | Andrew Bayer      | CloudBees  | [abayer](https://github.com/abayer)          |
+| <img width="30px" src="https://github.com/afrittoli.png">   | Andrea Frittoli   | IBM        | [afrittoli](https://github.com/afrittoli)    |
+| <img width="30px" src="https://github.com/bobcatfish.png">  | Christie Wilson   | Google     | [bobcatfish](https://github.com/bobcatfish)  |
+| <img width="30px" src="https://github.com/dibyom.png">      | Dibyo Mukherjee   | Google     | [dibyom](https://github.com/dibyom)          |
+| <img width="30px" src="https://github.com/vdemeester.png">  | Vincent Demeester | Red Hat    | [vdemeester](https://github.com/vdemeester)  |
+| <img width="30px" src="https://github.com/pritidesai.png">  | Priti Desai       | IBM        | [pritidesai](https://github.com/pritidesai)  |
+| <img width="30px" src="https://github.com/priyawadhwa.png"> | Priya Wadhwa      | Chainguard | [priyawadhwa](https://github.com/priyawadhwa)|
+| <img width="30px" src="https://github.com/jerop.png">       | Jerop Kipruto     | Google     | [jerop](https://github.com/jerop)            |
 
 ## Software Supply Chain Security (s3c)
 


### PR DESCRIPTION
1. Finishing up updates from governing board election (andrew bayer
   no longer on the board, priya wadhwa joining the board)
2. @jerop will be taking my place on the governing board while I am
   on leave (see [leave policy](https://github.com/tektoncd/community/blob/main/governance.md#governing-board-leave-policy))
   (thanks @jerop !!)

Went through the list at https://github.com/tektoncd/community/blob/main/governance.md#changes-to-governing-board
to make sure jerop and priya have all the governing board permissions
and to make the changes required with andrew leaving the board.

Also added Priti to the governing board + community meeting faciltator
rotation because she is listed in the rotation in the doc.

While running the permissions adding script I ran into a couple of
difficulties which I've tried to fix in:
* https://github.com/tektoncd/plumbing/pull/1062
* https://github.com/tektoncd/plumbing/pull/1061

PTAL @dibyom @vdemeester @afrittoli @priyawadhwa 