### PR TITLE
Add Lee Bernick to plumbing collaborators

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -573,6 +573,7 @@ orgs:
         - bobcatfish
         - afrittoli
         - sbwsg
+        - lbernick
         privacy: closed
         repos:
           plumbing: read


### PR DESCRIPTION
This commit adds lbernick to the plumbing collaborators. The requirements here are
to be nominated by another OWNER (with no objections from other OWNERs).