### PR TITLE
Add chitrangpatel as an organizational member

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -51,6 +51,7 @@ orgs:
     - chetan-rns
     - chmouel
     - chuangw6
+    - chitrangpatel
     - crshnburn
     - concaf
     - danielhelfand
@@ -526,6 +527,7 @@ orgs:
         members:
         - carlos-logro
         - chuangw6
+        - chitrangpatel
         - sthaha
         - iancoffey
         - a-roberts


### PR DESCRIPTION
I'm going to be making regular contributions to `Tekton` as a software developer at Google. Can I be added as an organizational member?