### PR TITLE
Add Lee Bernick to pipeline maintainers

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -231,6 +231,7 @@ orgs:
         - dlorenc
         - dibyom
         - jerop
+        - lbernick
         privacy: closed
         repos:
           pipeline: write


### PR DESCRIPTION
The current requirements for becoming a maintainer are:
- Participating in reviews for at least 3 months: The first PR to Pipelines I reviewed was #4368,
  opened on 11/9/21.
- Reviewed at least 30 PRs to the codebase: The [Tekton contributor dashboard](https://tekton.devstats.cd.foundation/d/9/developer-activity-counts-by-repository-group-table?orgId=1&var-period_name=Last%20year&var-metric=reviews&var-repogroup_name=tektoncd%2Fpipeline&var-country_name=All)
  shows that I have submitted 105 reviews to the pipelines repo in the past year, while the [Github UI](https://github.com/tektoncd/pipeline/pulls?q=is%3Apr+reviewed-by%3Albernick) shows
  42 pipelines PRs as reviewed by me (including a few of my own PRs). Not sure why there is such a large difference?
- Primary reviewer for at least 10 substantial PRs: #4705, #4734, #4739, #4659, #4663, #4596, #4502, #4402, #4715, #4760
- Broad knowledge of the project: I am an author for TEPs 0044, 0094, 0096, 0100, and 0104 (all related to Pipelines), and am coordinating our V1 release.
- Able to exercise judgment for the good of the project: I sure hope so but not sure I have any concrete evidence of this!
- Nominated by another maintainer: @dibyom