### PR TITLE
Add Lyndsey to dashboard.maintainers

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -244,7 +244,7 @@ orgs:
         members:
         - AlanGreene
         - briangleeson
-        - steveodonovan
+        - LyndseyBu
         privacy: closed
         repos:
           dashboard: write


### PR DESCRIPTION
Remove Steve from the Dashboard maintainers as he's no longer involved with
the project.

Add Lyndsey to the maintainers team. She has been contributing for over a year
now, providing great feedback in reviews, testing, providing input on design
changes, and helping to prepare for releases.

We've updated the OWNERS file in tektoncd/dashboard accordingly: https://github.com/tektoncd/dashboard/pull/2358