### PR TITLE
tep-84: Clarify pipelinerun attestation format

### DIFF
--- a/teps/0084-endtoend-provenance-collection.md
+++ b/teps/0084-endtoend-provenance-collection.md
@@ -120,7 +120,7 @@ With "chains", we are able to capture the signed provenance for individual `task
 * Ensure performance impact on pipeline execution is minimum
 * Any failure in the controller does not impact pipeline execution
 * All the verifications/enforcements during pipeline execution are currently out-of-scope (possibly should be addressed by separate pipeline admission controller)
-
+* Attest volumes and workspaces. Given that `taskrun` attestations also do not provide this information, a separate TEP is suggested to both narrow the scope of this TEP and ensure attesting volumes and workspaces is given the required focus.
 
 <!--
 What is out of scope for this TEP?  Listing non-goals helps to focus discussion
@@ -150,7 +150,6 @@ be handled, or user scenarios that will be affected and must be accomodated.
 
 * Must be possible to automatically attest `pipelineruns`
 * `pipelinerun` attestation must include parameters and results from `pipelinerun` and each of its `taskrun`
-* `pipelinerun` attestation must include information about volumes or workspaces used
 
 <!--
 TODO: Add requirements for event-payload
@@ -164,7 +163,7 @@ In this proposal, we are suggesting following extensions for an end-to-end and c
 As the event-payload is received by the `EventListener`, we need an interface to introspect/query payload so we can sign it from the controller.
 
 ##### 2. Provenance for pipelinerun
-In addition to individual `taskruns`, we collect the attestation for `pipelineruns`. This would allow us to attest: (a) list of all tasks executed in the pipelines (b) order in which these tasks were executed ( c) list of shared resources created/shared across tasks.
+In addition to individual `taskruns`, we collect the attestation for `pipelineruns`. This would allow us to attest: (a) list of all tasks executed in the pipelines (b) order in which these tasks were executed (c) list of parameters shared across tasks.
 
 Chains supports two attestation formats for `taskruns`: `tekton` and `in-toto`. Both must be supported for `pipelineruns` attestations.
 
@@ -176,16 +175,15 @@ The `in-toto` format created by chains wraps the [SLSA Provenance v0.2](https://
 * **predicate.buildType**: Chains sets this value to `https://tekton.dev/attestations/chains@v2` for `taskruns` attestations. In order to facilitate consumption, a different value should be used: `https://tekton.dev/attestations/chains/pipelinerun@v2`.
 * **predicate.invocation**: For `taskruns`, Chains populates this object with the task parameters. Similarly, Chains must populate this object with `pipelinerun` parameters. Default parameters must also be added.
 * **predicate.buildConfig**: For `taskruns`, Chains creates an object with a single attribute, `steps`, which corresponds to all the steps within the `taskrun`. For `pipelineruns`, Chains must instead set the attribute `tasks` which is an array of objects representing each `taskrun` in the `pipelinerun`. Notice that skipped tasks are not represented in the attestation since they do not contribute to builiding the image. Each object contains following attributes:
-  * **name**: The name of the `task` (not the `taskrun`) within the `pipelinerun`.
-  * **after**: The name of the `task` (not the `taskrun`) within the `pipelinerun` that was configured to be executed prior to this `taskrun`. If none, this field is omitted. The list of tasks in `predicate.buildConfig.tasks` is sorted by execution time. However, `taskruns` within a `pipelinerun` can be executed in parallel. This field helps reconstruct the multi-dimensional execution order of `taskruns`.
+  * **name**: The name of the `pipelinetask` within the `pipelinerun`.
+  * **after**: The name of the `pipelinetask` within the `pipelinerun` that was configured to be executed prior to this `taskrun`. If none, this field is omitted. The list of tasks in `predicate.buildConfig.tasks` is sorted by execution time. However, `taskruns` within a `pipelinerun` can be executed in parallel. This field helps reconstruct the multi-dimensional execution order of `taskruns`.
   * **status**: Either "Succeeded" or "Failed".
   * **ref.kind**: Either `ClusterTask` or `Task`.
-  * **ref.name**: The name of the `task` (not the `taskrun`!) within the k8s cluster or within the Tekton Bundle.
+  * **ref.name**: The name of the `task` within the k8s cluster or within the Tekton Bundle.
   * **ref.bundle**: Reference to the Tekton Bundle defining the task, or omitted if a Tekton Bundle was not used.
   * **startedOn**: When the `taskrun` started.
   * **finishedOn**: When the `taskrun` finished.
   * **steps**: The same information found in the `predicate.buildConfig.steps` of a `taskrun` attestation.
-  * **resources**: An array of objects mapping to any volume or workspace used by the `taskrun`. TODO: Requires further elaboration. Also track this at the `pipelinerun` level?
   * **invocation**: The same information found in the `predicate.invocation` of a `taskrun` attestation. This is needed to ensure default parameters on the task are visible in the attestation. It also maps pipeline parameters to task parameters.
   * **results**: An array of objects representing the results of a `taskrun`. Each object contains the attribute `name` and `value`. Their values are of type string. `taskrun` results are important in the context of a `pipelinerun` because `taskrun` results may be used by other tasks, thus impacting the output of the `pipelinerun`.
 * **predicate.materials**: For `taskruns`, Chains populates this object based on specially named task parameters or results, i.e. `CHAINS-GIT_COMMIT` and `CHAINS-GIT_URL`. Similarly, Chains must populate this object with the corresponding pipeline parameters or results.

--- a/teps/0084-endtoend-provenance-collection.md
+++ b/teps/0084-endtoend-provenance-collection.md
@@ -2,9 +2,10 @@
 status: proposed
 title: end-to-end provenance collection
 creation-date: '2021-09-16'
-last-updated: '2021-09-16'
+last-updated: '2022-05-12'
 authors:
 - '@nadgowdas'
+- '@lcarva'
 ---
 
 # TEP-0084: end-to-end provenance collection
@@ -69,7 +70,7 @@ tags, and then generate with `hack/update-toc.sh`.
 - [Motivation](#motivation)
   - [Goals](#goals)
   - [Non-Goals](#non-goals)
-  - [Use Cases (optional)](#use-cases-optional)
+  - [Use Cases](#use-cases)
 - [Requirements](#requirements)
 - [Proposal](#proposal)
       - [1. Event Signing Interface](#1-event-signing-interface)
@@ -112,13 +113,13 @@ With "chains", we are able to capture the signed provenance for individual `task
 * Attestation records are captured in popular formats like "in-toto"
 * These record(s) are automatically signed  and pushed to different storage backends (same techniques that chains employed)
 * The attestation record(s) for pipeline execution are self-contained to perform independent provenance audit
-* The attestation process is transparent to the user, in the sense user do not need to change their pipeline.
+* The attestation process is transparent to the user, in the sense user do not need to change their pipeline. However, changes to the pipeline and/or task definition may be required to comply with expected format
 
 ### Non-Goals
 
 * Ensure performance impact on pipeline execution is minimum
 * Any failure in the controller does not impact pipeline execution
-* All the verifications/enforcements during pipeline execution are currently out-of-scope (possibly should be addressed by seperate pipeline admission controller)
+* All the verifications/enforcements during pipeline execution are currently out-of-scope (possibly should be addressed by separate pipeline admission controller)
 
 
 <!--
@@ -126,7 +127,7 @@ What is out of scope for this TEP?  Listing non-goals helps to focus discussion
 and make progress.
 -->
 
-### Use Cases (optional)
+### Use Cases
 
 <!--
 Describe the concrete improvement specific groups of users will see if the
@@ -137,12 +138,22 @@ Cluster Admin? etc...) and experience (what workflows or actions are enhanced
 if this problem is solved?).
 -->
 
+1. **Deploy images built from a trusted pipeline.** As the maintainer of a containerized application, I want to verify that all the steps involved in building a container image have been performed by trusted operations. By attesting `pipelineruns`, all the tasks involved in building the container image are visible in a centralized location. It becomes obvious if a non-vetted task, e.g. `inject-miner`, was involved in building the container image.
+
 ## Requirements
 
 <!--
 Describe constraints on the solution that must be met. Examples might include
 performance characteristics that must be met, specific edge cases that must
 be handled, or user scenarios that will be affected and must be accomodated.
+-->
+
+* Must be possible to automatically attest `pipelineruns`
+* `pipelinerun` attestation must include parameters and results from `pipelinerun` and each of its `taskrun`
+* `pipelinerun` attestation must include information about volumes or workspaces used
+
+<!--
+TODO: Add requirements for event-payload
 -->
 
 ## Proposal
@@ -153,14 +164,39 @@ In this proposal, we are suggesting following extensions for an end-to-end and c
 As the event-payload is received by the `EventListener`, we need an interface to introspect/query payload so we can sign it from the controller.
 
 ##### 2. Provenance for pipelinerun
-In addition to individual `taskruns`, we collect the attestation for `pipelineruns`. This would allow us to attest: (a) list of all tasks executed in the pipelines (b) order in which these tasks were executed ( c) list of shared resources created/shared across tasks
+In addition to individual `taskruns`, we collect the attestation for `pipelineruns`. This would allow us to attest: (a) list of all tasks executed in the pipelines (b) order in which these tasks were executed ( c) list of shared resources created/shared across tasks.
+
+Chains supports two attestation formats for `taskruns`: `tekton` and `in-toto`. Both must be supported for `pipelineruns` attestations.
+
+The `tekton` format is simply the `Status` of a `taskrun`. Similarly, for `pipelineruns`, this should also be the `Status` of the `pipelinerun`.
+
+The `in-toto` format created by chains wraps the [SLSA Provenance v0.2](https://slsa.dev/provenance/v0.2) attestation format. The `in-toto` attestation itself should be the same for `taskruns` and `pipelineruns`. The `SLSA Provenance` attestation requires special attention:
+
+* **subject**: For `taskruns`, Chains processes the `taskrun` results and resources to determine which images were built then use this information to populate this field. For `pipelineruns`, Chains must instead process the `pipelinerun` results. Pipeline authors can easily set `pipelinerun` results based on `taskrun` results, allowing them to more easily use existing Tasks that do not conform to Chains type hinting while keeping the Chains implementation simpler (no deep inspection). Given that resources are deprecated, further support should not be added.
+* **predicate.buildType**: Chains sets this value to `https://tekton.dev/attestations/chains@v2` for `taskruns` attestations. In order to facilitate consumption, a different value should be used: `https://tekton.dev/attestations/chains/pipelinerun@v2`.
+* **predicate.invocation**: For `taskruns`, Chains populates this object with the task parameters. Similarly, Chains must populate this object with `pipelinerun` parameters. Default parameters must also be added.
+* **predicate.buildConfig**: For `taskruns`, Chains creates an object with a single attribute, `steps`, which corresponds to all the steps within the `taskrun`. For `pipelineruns`, Chains must instead set the attribute `tasks` which is an array of objects representing each `taskrun` in the `pipelinerun`. Notice that skipped tasks are not represented in the attestation since they do not contribute to builiding the image. Each object contains following attributes:
+  * **name**: The name of the `task` (not the `taskrun`) within the `pipelinerun`.
+  * **after**: The name of the `task` (not the `taskrun`) within the `pipelinerun` that was configured to be executed prior to this `taskrun`. If none, this field is omitted. The list of tasks in `predicate.buildConfig.tasks` is sorted by execution time. However, `taskruns` within a `pipelinerun` can be executed in parallel. This field helps reconstruct the multi-dimensional execution order of `taskruns`.
+  * **status**: Either "Succeeded" or "Failed".
+  * **ref.kind**: Either `ClusterTask` or `Task`.
+  * **ref.name**: The name of the `task` (not the `taskrun`!) within the k8s cluster or within the Tekton Bundle.
+  * **ref.bundle**: Reference to the Tekton Bundle defining the task, or omitted if a Tekton Bundle was not used.
+  * **startedOn**: When the `taskrun` started.
+  * **finishedOn**: When the `taskrun` finished.
+  * **steps**: The same information found in the `predicate.buildConfig.steps` of a `taskrun` attestation.
+  * **resources**: An array of objects mapping to any volume or workspace used by the `taskrun`. TODO: Requires further elaboration. Also track this at the `pipelinerun` level?
+  * **invocation**: The same information found in the `predicate.invocation` of a `taskrun` attestation. This is needed to ensure default parameters on the task are visible in the attestation. It also maps pipeline parameters to task parameters.
+  * **results**: An array of objects representing the results of a `taskrun`. Each object contains the attribute `name` and `value`. Their values are of type string. `taskrun` results are important in the context of a `pipelinerun` because `taskrun` results may be used by other tasks, thus impacting the output of the `pipelinerun`.
+* **predicate.materials**: For `taskruns`, Chains populates this object based on specially named task parameters or results, i.e. `CHAINS-GIT_COMMIT` and `CHAINS-GIT_URL`. Similarly, Chains must populate this object with the corresponding pipeline parameters or results.
+
 
 ##### 3. Attestation Format
 (As an optimizion option) Instead of creating seperate attestation records for `taskrun`, `pipelinerun`, `event-payload`, create a single attestation record at the "end" of a `pipelinerun` that includes everything.
 
 In our running example above, with this changes, for a given `image` we can attest that:
-1.  A pipeline was trigger by event with attested payload 
-2. In the pipeline, 3 tasks were execure in this order: "git-clone" --> "security-scan" --> "image-build". 
+1.  A pipeline was trigger by event with attested payload
+2. In the pipeline, 3 tasks were execure in this order: "git-clone" --> "security-scan" --> "image-build".
 3. The "image" was built from "clone-repo" dirpath, which was populated by "git-clone" task from {repo-url, revision} which match the signed event-payload.
 
 These attestations help audit/validate our pipeline executions for:
@@ -248,7 +284,7 @@ expectations).
 
 ## Design Evaluation
 <!--
-How does this proposal affect the reusability, simplicity, flexibility 
+How does this proposal affect the reusability, simplicity, flexibility
 and conformance of Tekton, as described in [design principles](https://github.com/tektoncd/community/blob/master/design-principles.md)
 -->
 

--- a/teps/README.md
+++ b/teps/README.md
@@ -229,7 +229,7 @@ This is the complete list of Tekton teps:
 |[TEP-0081](0081-add-chains-subcommand-to-the-cli.md) | Add Chains sub-command to the CLI | implemented | 2022-04-27 |
 |[TEP-0082](0082-workspace-hinting.md) | Workspace Hinting | proposed | 2021-10-26 |
 |[TEP-0083](0083-scheduled-and-polling-runs-in-tekton.md) | Scheduled and Polling runs in Tekton | proposed | 2021-09-13 |
-|[TEP-0084](0084-endtoend-provenance-collection.md) | end-to-end provenance collection | proposed | 2021-09-16 |
+|[TEP-0084](0084-endtoend-provenance-collection.md) | end-to-end provenance collection | proposed | 2022-05-12 |
 |[TEP-0085](0085-per-namespace-controller-configuration.md) | Per-Namespace Controller Configuration | proposed | 2021-10-14 |
 |[TEP-0086](0086-changing-the-way-result-parameters-are-stored.md) | Changing the way result parameters are stored | proposed | 2022-04-07 |
 |[TEP-0088](0088-result-summaries.md) | Tekton Results - Record Summaries | proposed | 2021-10-01 |


### PR DESCRIPTION
To assist in reviewing these changes, I've created an [example](https://github.com/lcarva/minimal-container/blob/178df1bfeb1b089bd22695f75aa99fd2d4fa679e/tekton/examples/pipelinerun-attestation-tep-84.json) pipelinerun attestation which was generated from a pipelinerun created from [this](https://github.com/lcarva/minimal-container/blob/178df1bfeb1b089bd22695f75aa99fd2d4fa679e/tekton/simple-build-pipeline.yaml) pipeline. 