### PR TITLE
TEP-0090: Matrix - Update Non Goals

### DIFF
--- a/teps/0090-matrix.md
+++ b/teps/0090-matrix.md
@@ -2,7 +2,7 @@
 status: implementable
 title: Matrix
 creation-date: '2021-10-13'
-last-updated: '2022-02-14'
+last-updated: '2022-06-09'
 authors:
 - '@jerop'
 - '@pritidesai'
@@ -208,16 +208,13 @@ The following are out of scope for this TEP:
 
 1. Terminating early when one of the `TaskRuns` or `Runs` created in parallel fails. As is currently, running `TaskRuns` 
 and `Runs` have to complete execution before termination.
-2. Controlling the concurrency of `TaskRuns` or `Runs` created in a given `matrix`. This will be addressed more broadly 
-in Tekton Pipelines ([tektoncd/pipeline: issue#2591][issue-2591], [tektoncd/experimental: issue#804][issue-804]).
-3. Configuring the `TaskRuns` or `Runs` created in a given `matrix` to execute sequentially. This remains an option that 
-we can explore later.
-4. Excluding generating a `TaskRun` or `Run` for a specific combination in the `matrix`. This can be handled using 
-guarded execution through `when` expressions. This remains an option we can explore later if needed.
-5. Including generating a `TaskRun` or `Run` for a specific combination in the `matrix`. This can be handled by adding 
-the items that produce that combination into the `matrix`, and using guarded execution through `when` expressions to 
-exclude the combinations that should be skipped. This remains an option we can explore later if needed.
-6. Supporting producing `Results` from fanned out `PipelineTasks`. We plan to address this after [TEP-0075][tep-0075]
+2. Configuring the `TaskRuns` or `Runs` created in a given `matrix` to execute sequentially. This remains an option 
+that we can explore later.
+3. Excluding generating a `TaskRun` or `Run` for a specific combination in the `matrix`. This remains an option we can
+explore later if needed.
+4. Including generating a `TaskRun` or `Run` for a specific combination in the `matrix`. This can be handled by adding 
+the items that produce that combination into the `matrix`. This remains an option we can explore later if needed.
+5. Supporting producing `Results` from fanned out `PipelineTasks`. We plan to address this after [TEP-0075][tep-0075]
 and [TEP-0076][tep-0076] have landed. 
 
 ### Requirements

--- a/teps/README.md
+++ b/teps/README.md
@@ -234,7 +234,7 @@ This is the complete list of Tekton teps:
 |[TEP-0086](0086-changing-the-way-result-parameters-are-stored.md) | Changing the way result parameters are stored | proposed | 2022-04-07 |
 |[TEP-0088](0088-result-summaries.md) | Tekton Results - Record Summaries | proposed | 2021-10-01 |
 |[TEP-0089](0089-nonfalsifiable-provenance-support.md) | Non-falsifiable provenance support | implementable | 2022-01-18 |
-|[TEP-0090](0090-matrix.md) | Matrix | implementable | 2022-02-14 |
+|[TEP-0090](0090-matrix.md) | Matrix | implementable | 2022-06-09 |
 |[TEP-0092](0092-scheduling-timeout.md) | Scheduling Timeout | implementable | 2022-04-11 |
 |[TEP-0094](0094-configuring-resources-at-runtime.md) | Configuring Resources at Runtime | implemented | 2022-03-11 |
 |[TEP-0095](0095-common-repository-configuration.md) | Common Repository Configuration | proposed | 2021-11-29 |


### PR DESCRIPTION
[TEP-0090: Matrix][tep-0090] proposed executing a `PipelineTask` in
parallel `TaskRuns` and `Runs` with substitutions from combinations
of `Parameters` in a `Matrix`.

In this change, we update the non-goals of TEP-0090:

1. In non-goal 2, we indicated that controlling concurrency is out
of scope. We actually ended up addressing controlling the concurrency
of `TaskRuns` or `Runs` created in a given `Matrix`. See [details][cc]
in the TEP. In this change, we remove this non-goal.

2. In non-goals 4 and 5, we suggested that `when` expressions can be
used to guard the execution of a particular combination of `Parameters`
from a `Matrix`. This is not possible because `when` expressions guard
the execution of the whole `PipelineTask` (and its `TaskRuns`/`Runs`).
In this change, we update those non-goals to remove this suggestion.

[tep-0090]: https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md
[cc]: https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md#concurrency-control

/kind tep