### PR TITLE
[TEP-0096] Rename PipelineRun.TaskRunSpecs fields

### DIFF
--- a/teps/0096-pipelines-v1-api.md
+++ b/teps/0096-pipelines-v1-api.md
@@ -235,6 +235,8 @@ This policy should be updated to include Tekton metrics as part of the API. No o
 #### API Changes
 
 - Fix [pain points](https://github.com/tektoncd/pipeline/issues/3792) associated with TaskRun and PipelineRun Status.
+- Rename PipelineRun's `spec.taskRunSpecs.taskServiceAccountName` to `spec.taskRunSpecs.serviceAccountName`.
+- Rename PipelineRun's `spec.taskRunSpecs.taskPodTemplate` to `spec.taskRunSpecs.podTemplate`.
 - Consider replacing any Task or Pipeline fields that should support parameterization with Strings and performing our own validation.
   - See [Handling parameter interpolation in fields not designed for it](https://github.com/tektoncd/pipeline/issues/1530) for more details.
 


### PR DESCRIPTION
This commit proposes renaming some fields of PipelineRun.TaskRunSpecs in v1 to avoid redundancy.

/kind tep