### PR TITLE
TEP-0090: Matrix - Minimal Status is Required

### DIFF
--- a/teps/0090-matrix.md
+++ b/teps/0090-matrix.md
@@ -2,7 +2,7 @@
 status: implementable
 title: Matrix
 creation-date: '2021-10-13'
-last-updated: '2022-06-09'
+last-updated: '2022-06-22'
 authors:
 - '@jerop'
 - '@pritidesai'
@@ -1348,8 +1348,10 @@ status:
       pipelineTaskName: foo
 ```
 
-The `ChildReferences` will be populated for matrixed `PipelineTasks` regardless of the embedded status flags
-because that is the API behavior we're migrating to.
+For `ChildReferences` to be populated, the `embedded-status` must be set to `"minimal"`. Thus, any `Pipeline` with a
+`PipelineTask` that has a `Matrix` will require that minimal embedded status is enabled during the migration until it
+becomes the only supported status. This requirement also makes the behavior clearer to users - auto-adding the minimal
+status when users have not enabled it makes the user experience opaque and surprising.
 
 ## Design Evaluation
 

--- a/teps/README.md
+++ b/teps/README.md
@@ -234,7 +234,7 @@ This is the complete list of Tekton teps:
 |[TEP-0086](0086-changing-the-way-result-parameters-are-stored.md) | Changing the way result parameters are stored | proposed | 2022-04-07 |
 |[TEP-0088](0088-result-summaries.md) | Tekton Results - Record Summaries | proposed | 2021-10-01 |
 |[TEP-0089](0089-nonfalsifiable-provenance-support.md) | Non-falsifiable provenance support | implementable | 2022-01-18 |
-|[TEP-0090](0090-matrix.md) | Matrix | implementable | 2022-06-09 |
+|[TEP-0090](0090-matrix.md) | Matrix | implementable | 2022-06-22 |
 |[TEP-0092](0092-scheduling-timeout.md) | Scheduling Timeout | implementable | 2022-04-11 |
 |[TEP-0094](0094-configuring-resources-at-runtime.md) | Configuring Resources at Runtime | implemented | 2022-03-11 |
 |[TEP-0095](0095-common-repository-configuration.md) | Common Repository Configuration | proposed | 2021-11-29 |


### PR DESCRIPTION
Prior to this change, we had agreed that the minimal status would
be auto-added for PipelineTasks which have a Matrix. During the
implementation, realized that it's unclear how we should handle
the other PipelineTasks in the Pipeline that don't have a Matrix.
Also realized that the automagic is opaque to users and could be
surprising to users who're not aware of the ChildReferences.

In this change, we propose that users have to enable the minimal
status to use Matrix. This is not a restrictive requirement as is
the direction we're moving to, and will become the default soon.
More importantly, it makes the behavior clear and the improves the
user experience.

/kind tep

cc @abayer