### PR TITLE
add @abayer to core.maintainers

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -237,6 +237,7 @@ orgs:
         - dibyom
         - jerop
         - lbernick
+        - abayer
         privacy: closed
         repos:
           pipeline: write


### PR DESCRIPTION
@abayer was added as a pipelines owner - this change adds him to the core.maintainers group