### PR TITLE
[TEP-0112] Add some more alternatives

### DIFF
--- a/teps/README.md
+++ b/teps/README.md
@@ -259,5 +259,5 @@ This is the complete list of Tekton teps:
 |[TEP-0108](0108-mapping-workspaces.md) | Mapping Workspaces | implemented | 2022-05-26 |
 |[TEP-0110](0110-decouple-catalog-organization-and-reference.md) | Decouple Catalog Organization and Resource Reference | implemented | 2022-06-29 |
 |[TEP-0111](0111-propagating-workspaces.md) | Propagating Workspaces | implementable | 2022-06-03 |
-|[TEP-0112](0112-replace-volumes-with-workspaces.md) | Replace Volumes with Workspaces | proposed | 2022-06-02 |
+|[TEP-0112](0112-replace-volumes-with-workspaces.md) | Replace Volumes with Workspaces | proposed | 2022-07-20 |
 |[TEP-0114](0114-custom-tasks-beta.md) | Custom Tasks Beta | implementable | 2022-07-12 |


### PR DESCRIPTION
This commit adds more options for supporting "dynamic" workspaces
and Task-internal workspaces. It also removes the option for adding
support for CSI volumes as workspace bindings, as this has been implemented.

/kind tep