### PR TITLE
[TEP-0096] Remove reference to parameterizing more fields

### DIFF
--- a/teps/0096-pipelines-v1-api.md
+++ b/teps/0096-pipelines-v1-api.md
@@ -237,8 +237,6 @@ This policy should be updated to include Tekton metrics as part of the API. No o
 - Fix [pain points](https://github.com/tektoncd/pipeline/issues/3792) associated with TaskRun and PipelineRun Status.
 - Rename PipelineRun's `spec.taskRunSpecs.taskServiceAccountName` to `spec.taskRunSpecs.serviceAccountName`.
 - Rename PipelineRun's `spec.taskRunSpecs.taskPodTemplate` to `spec.taskRunSpecs.podTemplate`.
-- Consider replacing any Task or Pipeline fields that should support parameterization with Strings and performing our own validation.
-  - See [Handling parameter interpolation in fields not designed for it](https://github.com/tektoncd/pipeline/issues/1530) for more details.
 - There have been several changes to API fields related to compute resources (see
 [TEP-0094](./0094-configuring-resources-at-runtime.md) and [TEP-0104](./0104-tasklevel-resource-requirements.md)).
 Therefore, step-level compute resource related fields should remain at their current stability levels


### PR DESCRIPTION
This commit removes parameterizing additional fields as a potential v1
subtask for 2 reasons:
- There's no longer a clear use case for this, and the issue is closed
- Our Go libraries compatibility policy has been updated to specify that
this type of change is not considered a breaking change to the API, so it
can be done at any time.

/kind tep