### PR TITLE
[TEP-0096] Leave step compute resources in beta

### DIFF
--- a/teps/0096-pipelines-v1-api.md
+++ b/teps/0096-pipelines-v1-api.md
@@ -240,6 +240,12 @@ This policy should be updated to include Tekton metrics as part of the API. No o
 - Rename PipelineRun's `spec.taskRunSpecs.taskPodTemplate` to `spec.taskRunSpecs.podTemplate`.
 - Consider replacing any Task or Pipeline fields that should support parameterization with Strings and performing our own validation.
   - See [Handling parameter interpolation in fields not designed for it](https://github.com/tektoncd/pipeline/issues/1530) for more details.
+- There have been several changes to API fields related to compute resources (see
+[TEP-0094](./0094-configuring-resources-at-runtime.md) and [TEP-0104](./0104-tasklevel-resource-requirements.md)).
+Therefore, step-level compute resource related fields should remain at their current stability levels
+until we are confident we have a consistent API for compute resources.
+`task.spec.steps[].resources` and `taskRun.spec.taskSpec.steps[].resources` should remain in beta,
+meaning that to enable these fields on v1 CRDs, the "enable-api-fields" flag should be set to "beta". 
 
 #### Deprecations
 


### PR DESCRIPTION
This commit proposes leaving API fields related to step-level
compute resources at their current stability levels until we
are confident that we have a compute resources API we want to stabilize.

/kind tep