### PR TITLE
[TEP-0104]: Update case with limits but no requests

### DIFF
--- a/teps/README.md
+++ b/teps/README.md
@@ -252,7 +252,7 @@ This is the complete list of Tekton teps:
 |[TEP-0101](0101-env-in-pod-template.md) | Env in POD template | proposed | 2022-05-16 |
 |[TEP-0102](0102-https-connection-to-triggers-interceptor.md) | HTTPS Connection to Triggers ClusterInterceptor | implementable | 2022-04-20 |
 |[TEP-0103](0103-skipping-reason.md) | Skipping Reason | implemented | 2022-05-05 |
-|[TEP-0104](0104-tasklevel-resource-requirements.md) | Task-level Resource Requirements | implementable | 2022-07-07 |
+|[TEP-0104](0104-tasklevel-resource-requirements.md) | Task-level Resource Requirements | implementable | 2022-08-08 |
 |[TEP-0105](0105-remove-pipeline-v1alpha1-api.md) | Remove Pipeline v1alpha1 API | implementable | 2022-05-17 |
 |[TEP-0106](0106-support-specifying-metadata-per-task-in-runtime.md) | Support Specifying Metadata per Task in Runtime | implemented | 2022-05-27 |
 |[TEP-0107](0107-propagating-parameters.md) | Propagating Parameters | implemented | 2022-05-26 |


### PR DESCRIPTION
This commit focuses on the behavior of Task-level resource requirements
in the case where a user specifies Task-level limits but not Task-level
requests. In this case, we must set some requests, as Kubernetes' default
behavior will result in overall requests that are too large. This commit
proposes setting Task-level requests equal to Task-level limits, similar
to the behavior used by Kubernetes.

/kind tep