### PR TITLE
Add adambkaplan to the tektoncd org

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -19,6 +19,7 @@ orgs:
     location: ''
     members:
     - abayer
+    - adambkaplan
     - 16yuki0702
     - AlanGreene
     - alhuizenga


### PR DESCRIPTION
Add adambkaplan (me!) to the Tekton GitHub organization. @dibyom and
@vdemeester have nominated me to be an approver for Results.

Signed-off-by: Adam Kaplan <adam@adambkaplan.com>