### PR TITLE
TEP-0114: Custom Tasks Beta - Remove Pod Template

### DIFF
--- a/teps/0114-custom-tasks-beta.md
+++ b/teps/0114-custom-tasks-beta.md
@@ -24,6 +24,7 @@ see-also:
     - [API Changes](#api-changes)
       - [v1alpha1 to v1beta1 + Run to CustomRun](#v1alpha1-to-v1beta1--run-to-customrun)
       - [References and Specifications](#references-and-specifications)
+      - [Remove Pod Template](#remove-pod-template)
       - [Feature Gates](#feature-gates)
     - [Documentation](#documentation)
     - [Testing](#testing)
@@ -190,6 +191,14 @@ spec:
 
 Simplifying all the references to use `ref` and embedded specifications to use `spec` is out of scope for this TEP. That
 work is tracked in [tektoncd/pipeline#5138][5138].
+
+##### Remove Pod Template
+
+Remove `podTemplate` field that assumes and implies that all `Custom Tasks` create `Pods`. 
+
+Note that the goal of `Custom Tasks`, as defined in [TEP-0002][tep-0002], is to support non-Pod `Task` implementations.
+If a specific `Custom Task` implementation creates `Pods`, that `Custom Task` can have a `Pod` template field in its
+own specification.
 
 ##### Feature Gates
 


### PR DESCRIPTION
In v1alpha1, `Runs` have `Pod` templates. However, `Runs` do not always create `Pods`. 

In this change, we propose that `Runs` in v1beta1 should not have `Pod` templates - specific `Custom Tasks` implementation can support that in their own specifications.

Context: https://github.com/tektoncd/pipeline/pull/5403#discussion_r960774532

Many thanks to @lbernick for catching this issue!

/kind tep

cc @vsinghai @lbernick @vdemeester