### PR TITLE
Add Tekton community-wide release policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Tekton community.
 - [our shared document drive](contact.md#shared-drive)
 - [our shared calendar](contact.md#calendar)
 
-For October 2021: check out our [Hacktoberfest](./hacktoberfest-2021.md) ideas!
-
 See our standards regarding:
 
 - [Code of conduct](code-of-conduct.md)
@@ -27,6 +25,7 @@ See our standards regarding:
 - [Commits](standards.md#commits)
 - [Code](standards.md#code)
 - [User profiles](user-profiles.md)
+- [Releases](releases.md)
 
 Find out about our processes:
 

--- a/releases.md
+++ b/releases.md
@@ -1,0 +1,103 @@
+# Tekton Release Cycles
+
+## Support Policy
+
+The Tekton project maintains three release branches for each project, created one per quarter, which 
+results in a overall support window of approximately one year for each of these releases.
+
+This approach allows Tekton to roughly align to the [Kubernetes release cycles][kube-releases] and 
+maintain three supported releases at any point in time.
+
+Tekton is made of a collection of project, and each project may define its own release cadence, as long as
+this [support policy](#support-policy) is followed. 
+
+Examples:
+
+- A project may release on a monthly basis, and maintain a release branch for every fourth release
+- A project may release on a quarterly basis, and maintain a release branch for the three most recent minor 
+  releases
+
+## Release Numbers
+
+Tekton uses [semantic versioning][semantic] to version its own releases. Release numbers are in the format
+MAJOR.MINOR.PATCH `vX.Y`. The [support policy](#support-policy) applies to MAJOR and MINOR releases alike.
+
+## Release Tags and Branches
+
+Every time a Tekton project produces a release, a new tag `vX.Y.Z` is created, as well as a new branch that
+initially points to the git tag `vX.Y.Z`.
+
+- Supported releases: 
+    - branch name: `release-vX.N-lts`
+    - support window: until `release-vX.N+3`
+
+- Any other major or minor release:
+    - branch name: `release-vX.M`
+    - support window: until `release-vX.M+1`
+
+Once a release support window expires, the corresponding branch is deleted.
+It is recommended (but not mandatory) to make major releases coincide with supported ones.
+
+## Milestones
+
+Tekton projects may use [GitHub milestones][github-milestones] to plan their next release. This helps the
+maintainer and reviewer team to focus their work for the release and it gives users visibility on what they
+may expect for the upcoming releases.
+
+When used, milestone names must include the release number in `v<MAJOR>.<MINOR>` format.
+Once a release is made the milestone is closed. Patch releases are not tracked as part of the milestone.
+
+## Project Requirements
+
+Project must include release documentation in a `releases.md` file, which must include:
+
+- The release frequency adopted by the project
+- The first release where this [support policy](#support-policy) applies
+- A list of one year worth of releases. For each release:
+    - Number, name, date released, link to release notes
+    - End of life (EOL) date
+    - List of patch releases, each with link to release notes
+
+The document may include extra project-specific, user-facing release documentation.
+
+## Nightly Builds
+
+Tekton projects are encouraged to produce nightly builds, also called nightly releases.
+Nightly builds are produced for the benefit of Tekton users and developers but are not supported
+after they are produced. Users who rely on nightly builds must move to a newer nightly build or release to
+pick up any required bugfix, security patch or new feature. 
+
+Tekton projects always strive to keep the main branch in a consistent and usable state, however it may be
+possible for nightly builds to include partially implemented features and removal of deprecated features
+that will be thoroughly documented in the next upcoming release.
+
+The [plumbing][nightly-plumbing] repository contains the Tekton resources to be used to produce nightly
+builds. The plumbing repository includes examples of [nightly-build pipelines][nightly-pipeline] that projects
+may use to created their own. Nightly builds are triggered by [cronjobs][nightly-triggers] running
+in the *dogfooding* cluster.
+
+Each nightly build is associated to a git tag, which includes the date and short version of the git sha:
+
+```shell
+VERSION_TAG="v$(date +"%Y%m%d")-$(echo $GIT_SHA | cut -c 1-10)"
+```
+
+## Nightly releases
+
+Tekton projects may decide to produce nightly releases. 
+Additional requirements compared to nightly builds are:
+
+- fully automated release notes associated to each nightly release
+- the project must choose one nightly release per quarter, give it a semantic version, create a release branch
+  and support the release according to the [support policy](#support-policy)
+- the project documentation on the [Tekton website]tekton-web] must include the latest nightly release plus all
+  currently supported long term releases
+
+
+[kube-releases]: (https://kubernetes.io/releases/)
+[semantic]: https://semver.org/
+[github-milestones]: https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones
+[nightly-plumbing]: https://github.com/tektoncd/plumbing/tree/main/tekton/resources/nightly-release
+[nightly-pipeline]: https://github.com/tektoncd/plumbing/tree/main/tekton/ci/cluster-interceptors/build-id/tekton
+[nightly-triggers]: https://github.com/tektoncd/plumbing/tree/main/tekton/cronjobs/dogfooding/releases
+[tekton-web]: https://tekton.dev/docs

--- a/releases.md
+++ b/releases.md
@@ -20,7 +20,7 @@ Examples:
 ## Release Numbers
 
 Tekton uses [semantic versioning][semantic] to version its own releases. Release numbers are in the format
-MAJOR.MINOR.PATCH `vX.Y`. The [support policy](#support-policy) applies to MAJOR and MINOR releases alike.
+MAJOR.MINOR.PATCH `vX.Y.Z`. The [support policy](#support-policy) applies to MAJOR and MINOR releases alike.
 
 ## Release Tags and Branches
 
@@ -35,7 +35,7 @@ initially points to the git tag `vX.Y.Z`.
     - branch name: `release-vX.M`
     - support window: until `release-vX.M+1`
 
-Once a release support window expires, the corresponding branch is deleted.
+Once a release support window expires, the corresponding branch is deleted. Tags are never deleted.
 It is recommended (but not mandatory) to make major releases coincide with supported ones.
 
 ## Milestones
@@ -85,8 +85,9 @@ VERSION_TAG="v$(date +"%Y%m%d")-$(echo $GIT_SHA | cut -c 1-10)"
 
 ## Nightly releases
 
-Tekton projects may decide to produce nightly releases. 
-Additional requirements compared to nightly builds are:
+Tekton projects may decide to migrate from nightly builds to nightly releases, and use nightly releases to
+replace other releases completely. If a projects decides to do so, it must still comply with the
+[support policy](#support-policy), so the following requirements must be met:
 
 - fully automated release notes associated to each nightly release
 - the project must choose one nightly release every four months, give it a semantic version, create a release branch

--- a/releases.md
+++ b/releases.md
@@ -2,19 +2,19 @@
 
 ## Support Policy
 
-The Tekton project maintains three release branches for each project, created one per quarter, which 
+The Tekton project maintains three release branches for each project, created one every four months, which
 results in a overall support window of approximately one year for each of these releases.
 
 This approach allows Tekton to roughly align to the [Kubernetes release cycles][kube-releases] and 
-maintain three supported releases at any point in time.
+maintain **four** supported releases at any point in time.
 
-Tekton is made of a collection of project, and each project may define its own release cadence, as long as
+Tekton is made of a collection of projects, and each project may define its own release cadence, as long as
 this [support policy](#support-policy) is followed. 
 
 Examples:
 
 - A project may release on a monthly basis, and maintain a release branch for every fourth release
-- A project may release on a quarterly basis, and maintain a release branch for the three most recent minor 
+- A project may release every four months, and maintain a release branch for the three most recent minor
   releases
 
 ## Release Numbers
@@ -41,7 +41,7 @@ It is recommended (but not mandatory) to make major releases coincide with suppo
 ## Milestones
 
 Tekton projects may use [GitHub milestones][github-milestones] to plan their next release. This helps the
-maintainer and reviewer team to focus their work for the release and it gives users visibility on what they
+maintainer and reviewer teams to focus their work for the release and it gives users visibility on what they
 may expect for the upcoming releases.
 
 When used, milestone names must include the release number in `v<MAJOR>.<MINOR>` format.
@@ -54,9 +54,9 @@ Project must include release documentation in a `releases.md` file, which must i
 - The release frequency adopted by the project
 - The first release where this [support policy](#support-policy) applies
 - A list of one year worth of releases. For each release:
-    - Number, name, date released, link to release notes
+    - Number, name, date released, link to [release notes][release-notes-guidelines]
     - End of life (EOL) date
-    - List of patch releases, each with link to release notes
+    - List of patch releases, each with link to [release notes][release-notes-guidelines]
 
 The document may include extra project-specific, user-facing release documentation.
 
@@ -76,7 +76,8 @@ builds. The plumbing repository includes examples of [nightly-build pipelines][n
 may use to created their own. Nightly builds are triggered by [cronjobs][nightly-triggers] running
 in the *dogfooding* cluster.
 
-Each nightly build is associated to a git tag, which includes the date and short version of the git sha:
+Nightly builds are not tagged in git. The container images associated to nightly builds are tagged.
+The tag includes the date and short version of the git sha:
 
 ```shell
 VERSION_TAG="v$(date +"%Y%m%d")-$(echo $GIT_SHA | cut -c 1-10)"
@@ -88,7 +89,7 @@ Tekton projects may decide to produce nightly releases.
 Additional requirements compared to nightly builds are:
 
 - fully automated release notes associated to each nightly release
-- the project must choose one nightly release per quarter, give it a semantic version, create a release branch
+- the project must choose one nightly release every four months, give it a semantic version, create a release branch
   and support the release according to the [support policy](#support-policy)
 - the project documentation on the [Tekton website]tekton-web] must include the latest nightly release plus all
   currently supported long term releases
@@ -101,3 +102,4 @@ Additional requirements compared to nightly builds are:
 [nightly-pipeline]: https://github.com/tektoncd/plumbing/tree/main/tekton/ci/cluster-interceptors/build-id/tekton
 [nightly-triggers]: https://github.com/tektoncd/plumbing/tree/main/tekton/cronjobs/dogfooding/releases
 [tekton-web]: https://tekton.dev/docs
+[release-notes-guidelines]: https://github.com/tektoncd/community/blob/main/standards.md#release-notes


### PR DESCRIPTION
Add policy and guidelines for Tekton projects about releases. This defines the required support policy for Tekton releases, also referred to as long-term-policy (LTS).

This is based on the discussion during the community/governace working group of Sept 13th 2022, plus extra proposed details.

Partially addresses: https://github.com/tektoncd/community/issues/806

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>