### PR TITLE
Callout publicly known CVEs for release notes

### DIFF
--- a/standards.md
+++ b/standards.md
@@ -52,6 +52,7 @@ Refer to the following set of questions to help fill the release-note section.
   * If no, just write "NONE" in the release-note block.
   * If yes, a release note is required:
     * Enter detailed release note in the release-note block. If the PR requires additional action from users switching to the new release, include the string "ACTION REQUIRED".
+    * If this PR addresses a publicly known CVE, include the CVE number in the release notes
   * If unsure, include release note.
     * It's recommended to include release note explaining the changes in the PR.
 


### PR DESCRIPTION
Complement existing release note standards with a note about documenting any publicly known CVE specifically addressed by a PR.

This is a requirement for the OpenSSF badge:

> The release notes MUST identify every publicly known run-time vulnerability fixed in this release that already had a CVE assignment or similar when the release was created. This criterion may be marked as not applicable (N/A) if users typically cannot practically update the software themselves (e.g., as is often true for kernel updates). This criterion applies only to the project results, not to its dependencies. If there are no release notes or there have been no publicly known vulnerabilities, choose N/A.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>