### PR TITLE
Clarify LTS, support and number of releases

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -2,20 +2,35 @@
 
 ## Support Policy
 
-The Tekton project maintains three release branches for each project, created one every four months, which
-results in a overall support window of approximately one year for each of these releases.
+The Tekton project maintains four release branches for each project, created one every three months,
+which results in a overall support window of approximately one year for each of these releases.
 
-This approach allows Tekton to roughly align to the [Kubernetes release cycles][kube-releases] and 
-maintain **four** supported releases at any point in time.
+This approach means that Tekton supports **four** releases at any point in time, called long term
+support (LTS) releases. Throughout the support period, patch releases may be created to resolve:
+
+- CVEs (under the advisement of the Tekton Vulnerability Team)
+- dependency issues (including base image updates)
+- critical core component issues
 
 Tekton is made of a collection of projects, and each project may define its own release cadence, as long as
-this [support policy](#support-policy) is followed. 
+this [support policy](#support-policy) is followed.
 
 Examples:
 
 - A project may release on a monthly basis, and maintain a release branch for every fourth release
 - A project may release every four months, and maintain a release branch for the three most recent minor
   releases
+
+Individual projects may provide short support windows for non-LTS major or minor releases, which may last
+until the next major or minor release is available.
+
+Note that the support policy is independent from the any API stability policy provided by projects.
+If a release by mistake broke an API stability policy, during the support period that would justify
+the creation a patch release to resolve the issue.
+
+Deprecations are not affected by support: if a feature or API version is deprecated in a release, the
+deprecation is effective immediately, for both LTS and non-LTS release. On the flip side, regular support
+for the release is provided until the release EOL, regardless on any deprecation it may include.
 
 ## Release Numbers
 
@@ -27,7 +42,7 @@ MAJOR.MINOR.PATCH `vX.Y.Z`. The [support policy](#support-policy) applies to MAJ
 Every time a Tekton project produces a release, a new tag `vX.Y.Z` is created, as well as a new branch that
 initially points to the git tag `vX.Y.Z`.
 
-- Supported releases: 
+- Supported releases:
     - branch name: `release-vX.N-lts`
     - support window: until `release-vX.N+3`
 
@@ -65,7 +80,7 @@ The document may include extra project-specific, user-facing release documentati
 Tekton projects are encouraged to produce nightly builds, also called nightly releases.
 Nightly builds are produced for the benefit of Tekton users and developers but are not supported
 after they are produced. Users who rely on nightly builds must move to a newer nightly build or release to
-pick up any required bugfix, security patch or new feature. 
+pick up any required bugfix, security patch or new feature.
 
 Tekton projects always strive to keep the main branch in a consistent and usable state, however it may be
 possible for nightly builds to include partially implemented features and removal of deprecated features
@@ -96,7 +111,7 @@ replace other releases completely. If a projects decides to do so, it must still
   currently supported long term releases
 
 
-[kube-releases]: (https://kubernetes.io/releases/)
+[kube-releases]: https://kubernetes.io/releases/
 [semantic]: https://semver.org/
 [github-milestones]: https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones
 [nightly-plumbing]: https://github.com/tektoncd/plumbing/tree/main/tekton/resources/nightly-release


### PR DESCRIPTION
The policy covers support for releases but it does not explicitly mention LTS anywhere, term which is used in releases.md files across Tekton projects. Introduce the LTS term and explain how it relates to the policy.

The term support is not clarified today - it implicitly aligns to what we do today, so make that explicit in the policy and list reason that justify a new patch release.

The policy today talks about four supported releases which matches the Jan/Apr/Jul/Oct used by several projects in their releases.md. To match that we shall do an LTS release every three months, not four. Kubernets does three minor/major releases per year, so in fact this policy does not align to the kubernets one, thus remove the sentece about that.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>