### PR TITLE
TEP-0114: Keep `Retries` and `RetriesStatus` in the Scope

### DIFF
--- a/teps/0114-custom-tasks-beta.md
+++ b/teps/0114-custom-tasks-beta.md
@@ -2,7 +2,7 @@
 status: implementable
 title: Custom Tasks Beta
 creation-date: '2022-07-12'
-last-updated: '2022-10-20'
+last-updated: '2022-11-14'
 authors:
 - '@jerop'
 see-also:
@@ -26,7 +26,6 @@ see-also:
       - [v1alpha1 to v1beta1 + Run to CustomRun](#v1alpha1-to-v1beta1--run-to-customrun)
       - [References and Specifications](#references-and-specifications)
       - [Remove Pod Template](#remove-pod-template)
-      - [Exclude Retries and RetriesStatus](#exclude-retries-and-retriesstatus)
       - [Feature Gates](#feature-gates)
     - [Documentation](#documentation)
     - [Testing](#testing)
@@ -201,12 +200,6 @@ Remove `podTemplate` field that assumes and implies that all `Custom Tasks` crea
 Note that the goal of `Custom Tasks`, as defined in [TEP-0002][tep-0002], is to support non-Pod `Task` implementations.
 If a specific `Custom Task` implementation creates `Pods`, that `Custom Task` can have a `Pod` template field in its
 own specification.
-
-##### Exclude Retries and RetriesStatus
-
-Exclude `retries` and `retriesStatus` fields in the initial release. These fields are under active discussion in
-[TEP-0121][tep-0121]. These fields may be reintroduced or replacement features may be implemented, depending on the 
-design decisions we make in [TEP-0121][tep-0121].
 
 ##### Feature Gates
 

--- a/teps/README.md
+++ b/teps/README.md
@@ -281,7 +281,7 @@ This is the complete list of Tekton teps:
 |[TEP-0110](0110-decouple-catalog-organization-and-reference.md) | Decouple Catalog Organization and Resource Reference | implemented | 2022-06-29 |
 |[TEP-0111](0111-propagating-workspaces.md) | Propagating Workspaces | implemented | 2022-09-16 |
 |[TEP-0112](0112-replace-volumes-with-workspaces.md) | Replace Volumes with Workspaces | proposed | 2022-07-20 |
-|[TEP-0114](0114-custom-tasks-beta.md) | Custom Tasks Beta | implementable | 2022-10-20 |
+|[TEP-0114](0114-custom-tasks-beta.md) | Custom Tasks Beta | implementable | 2022-11-14 |
 |[TEP-0115](0115-tekton-catalog-git-based-versioning.md) | Tekton Catalog Git-Based Versioning | implementable | 2022-10-03 |
 |[TEP-0116](0116-referencing-finally-task-results-in-pipeline-results.md) | Referencing Finally Task Results in Pipeline Results | implemented | 2022-08-11 |
 |[TEP-0117](0117-tekton-results-logs.md) | Tekton Results Logs | implementable | 2022-10-21 |


### PR DESCRIPTION
We've decided to move forward with keeping `Retries` and `RetriesStatus` in CustomRun Beta release in [2022.11.14 API WG](https://docs.google.com/document/d/17PodAxG8hV351fBhSu7Y_OIPhGTVgj6OJ2lPphYYRpU/edit#bookmark=id.n7b1ert0qisv). Updating this TEP to reflect the change.

cc @jerop @abayer @tektoncd/core-maintainers 