### PR TITLE
Add TEP-0086 Working Group

### DIFF
--- a/working-groups.md
+++ b/working-groups.md
@@ -398,3 +398,16 @@ TBD [community#629](https://github.com/tektoncd/community/issues/629)).
 | <img width="30px" src="https://github.com/imjasonh.png">   | Jason Hall      | Red Hat | [imjasonh](https://github.com/imjasonh)     |
 | <img width="30px" src="https://github.com/afrittoli.png">  | Andrea Frittoli | IBM     | [afrittoli](https://github.com/afrittoli)   |
 | <img width="30px" src="https://github.com/xchapter7x.png"> | John Calabrese  | Google  | [xchapter7x](https://github.com/xchapter7x) |
+
+## TEP-0086: Larger Results
+
+This working group is all about proposing and discussing changes to [TEP-0086: Larger Results][tep-0086], and related
+topics such as Workspaces and Artifacts.
+
+| Artifact                   | Link                                                                                                                                                                                  |
+|----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Forum                      | [tekton-dev@](https://groups.google.com/forum/#!forum/tekton-dev)                                                                                                                     |
+| Meeting Notes              | [Notes](https://docs.google.com/document/d/1z2ME1o_XHvqv6cVEeElljvqVqHV8-XwtXdTkNklFU_8/edit)                                                                                         |
+| Slack Channel              | [#tep-0086](https://tektoncd.slack.com/messages/tep-0086)                                                                                                                             |
+| Community Meeting VC       | [https://zoom.us/j/94243917326?pwd=MThrUVVDSnlEU2FNWG10Yk1CcnRlZz09](https://zoom.us/j/94243917326?pwd=MThrUVVDSnlEU2FNWG10Yk1CcnRlZz09)                                              |
+| Community Meeting Calendar | Wednesday every week, 04:00p-04:30p UTC <br>[Calendar](https://calendar.google.com/calendar?cid=Z29vZ2xlLmNvbV9kM292Y3ZvMXAzMjE5aDk4OTU3M3Y5OGZuc0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t) |


### PR DESCRIPTION
We recently started a TEP-0086 Working Group. This change adds it to the list of working groups for visibility and transparency in the community.

cc @tektoncd/governing-board 