### PR TITLE
TEP-0121: Add status transition details

### DIFF
--- a/teps/README.md
+++ b/teps/README.md
@@ -288,7 +288,7 @@ This is the complete list of Tekton teps:
 |[TEP-0118](0118-matrix-with-explicit-combinations-of-parameters.md) | Matrix with Explicit Combinations of Parameters | implementable | 2022-08-08 |
 |[TEP-0119](0119-add-taskrun-template-in-pipelinerun.md) | Add taskRun template in PipelineRun | implementable | 2022-09-01 |
 |[TEP-0120](0120-canceling-concurrent-pipelineruns.md) | Canceling Concurrent PipelineRuns | proposed | 2022-09-23 |
-|[TEP-0121](0121-refine-retries-for-taskruns-and-customruns.md) | Refine Retries for TaskRuns and CustomRuns | implementable | 2022-11-14 |
+|[TEP-0121](0121-refine-retries-for-taskruns-and-customruns.md) | Refine Retries for TaskRuns and CustomRuns | implementable | 2022-12-01 |
 |[TEP-0122](0122-complete-build-instructions-and-parameters.md) | Complete Build Instructions and Parameters | proposed | 2022-11-29 |
 |[TEP-0123](0123-specifying-on-demand-retry-in-pipelinetask.md) | Specifying on-demand-retry in a PipelineTask | proposed | 2022-10-11 |
 |[TEP-0124](0124-distributed-tracing-for-tasks-and-pipelines.md) | Distributed tracing for Tasks and Pipelines | implementable | 2022-10-16 |


### PR DESCRIPTION
Add an explaination on how a status changes with every retry of a taskRun/customRun. Adding an example here to show the transition when a task fails v/s a task timesout.

Open this PR to continue the discussion in https://github.com/tektoncd/community/pull/882 as Priti will be out next Month

This PR makes some modifications to address https://github.com/tektoncd/community/pull/882#discussion_r1037161026. See the file diff result between the two PRs: https://www.diffchecker.com/tmp7Jmmr

cc @pritidesai @jerop @afrittoli 