### PR TITLE
[TEP-0115] Mark TEP-0115 as Implemented

### DIFF
--- a/teps/0115-tekton-catalog-git-based-versioning.md
+++ b/teps/0115-tekton-catalog-git-based-versioning.md
@@ -1,8 +1,8 @@
 ---
-status: implementable
+status: implemented
 title: Tekton Catalog Git-Based Versioning
 creation-date: '2022-07-12'
-last-updated: '2022-11-09'
+last-updated: '2022-12-14'
 authors:
 - "@jerop"
 - "@vdemeester"
@@ -44,6 +44,7 @@ see-also:
     - [Tekton Hub Git-Based Versioning](#tekton-hub-git-based-versioning)
     - [One resource per Catalog](#one-resource-per-catalog)
     - [Submodules in Catalogs](#submodules-in-catalogs)
+  - [Implementation PRs](#implementation-prs)
   - [References](#references)
 <!-- /toc -->
 
@@ -783,6 +784,13 @@ that can be in one Catalog with a shared git-based versioning.
 We could require that each resource is defined in its own repository, then they are included in the Catalog as
 [submodules][submodules]. This will ensure that each resource will have its own tag, hence its own versioning.
 This could be a future optimization, if needed.
+
+## Implementation PRs
+
+- [Git Resolver revision resolution](https://github.com/tektoncd/resolution/pull/75)
+- [Artifact Hub Resolver](https://github.com/tektoncd/pipeline/pull/5666)
+- [Catlin git-based validation](https://github.com/tektoncd/catlin/pull/6)
+- [Artifact Hub Git-based versioning](https://github.com/artifacthub/hub/pull/2337)
 
 ## References
 

--- a/teps/README.md
+++ b/teps/README.md
@@ -282,7 +282,7 @@ This is the complete list of Tekton teps:
 |[TEP-0111](0111-propagating-workspaces.md) | Propagating Workspaces | implemented | 2022-09-16 |
 |[TEP-0112](0112-replace-volumes-with-workspaces.md) | Replace Volumes with Workspaces | proposed | 2022-07-20 |
 |[TEP-0114](0114-custom-tasks-beta.md) | Custom Tasks Beta | implemented | 2022-12-12 |
-|[TEP-0115](0115-tekton-catalog-git-based-versioning.md) | Tekton Catalog Git-Based Versioning | implementable | 2022-11-09 |
+|[TEP-0115](0115-tekton-catalog-git-based-versioning.md) | Tekton Catalog Git-Based Versioning | implemented | 2022-12-14 |
 |[TEP-0116](0116-referencing-finally-task-results-in-pipeline-results.md) | Referencing Finally Task Results in Pipeline Results | implemented | 2022-08-11 |
 |[TEP-0117](0117-tekton-results-logs.md) | Tekton Results Logs | implementable | 2022-10-21 |
 |[TEP-0118](0118-matrix-with-explicit-combinations-of-parameters.md) | Matrix with Explicit Combinations of Parameters | implementable | 2022-08-08 |


### PR DESCRIPTION
This commit updates TEP-0115 to be `Implemented`.

The Tekton Hub to Artifact Hub Migration is tracked in: https://github.com/tektoncd/hub/issues/667
The Verified Catalogs Migration is scoped in [TEP-0079][tep-0079] and is tracked in: https://github.com/tektoncd/community/issues/889

[tep-0079]: https://github.com/tektoncd/community/blob/main/teps/0079-tekton-catalog-support-tiers.md