### PR TITLE
TEP-0127: Larger Results via Sidecar Logs - Mark as Implemented

### DIFF
--- a/teps/0127-larger-results-via-sidecar-logs.md
+++ b/teps/0127-larger-results-via-sidecar-logs.md
@@ -1,8 +1,8 @@
 ---
-status: implementable
+status: implemented
 title: Larger Results via Sidecar Logs
 creation-date: '2022-11-30'
-last-updated: '2022-12-01'
+last-updated: '2022-12-15'
 authors:
 - '@chitrangpatel'
 - '@jerop'
@@ -128,7 +128,7 @@ After the `Steps` have terminated, the `TaskRun` controller will write the `Resu
 instead of using the `Termination Message`, hence bypassing the 4KB limit. This approach keeps the rest of the existing
 functionality the same and does not require any external storage mechanism.
 
-For further details, see the [demonstration][demo] of the [implementation][poc].
+For further details, see the [demonstration][demo].
 
 This proposal provides an opportunity to experiment with this solution to provide `Results` within the CRDs as we
 continue to explore other alternatives, including those that involve external storage.
@@ -195,7 +195,7 @@ The `Sidecar` will run a binary that:
 - when all `Steps` have completed, it immediately parses all the `Results` in paths and prints them to stdout in a
   parsable pattern.
 
-For further details, see the [demonstration][demo] of the [implementation][poc].
+For further details, see the [demonstration][demo].
 
 ## Design Evaluation
 
@@ -257,7 +257,7 @@ These are some questions we plan to answer in the experiment:
 ## References
 
 - Implementation:
-  - [Implementation Pull Request][poc]
+  - [Implementation Pull Requests][prs]
   - [Demonstration by Chitrang][demo]
 - Tekton Enhancement Proposals:
   - [TEP-0075: Object Parameters and Results][tep-0075]
@@ -284,7 +284,7 @@ These are some questions we plan to answer in the experiment:
 [L3]: https://slsa.dev/spec/v0.1/levels
 [crd-size]: https://github.com/kubernetes/kubernetes/issues/82292
 [demo]: https://drive.google.com/file/d/1NrWudE_XBqweomiY24DP2Txnl1yN0yD9/view
-[poc]: https://github.com/tektoncd/pipeline/pull/5695
+[prs]: https://github.com/tektoncd/pipeline/pulls?q=is%3Apr+tep-0127+
 [performance]: https://github.com/tektoncd/community/pull/745#issuecomment-1206668381
 [tep-0075]: ./0075-object-param-and-result-types.md
 [tep-0076]: ./0076-array-result-types.md

--- a/teps/README.md
+++ b/teps/README.md
@@ -293,4 +293,4 @@ This is the complete list of Tekton teps:
 |[TEP-0123](0123-specifying-on-demand-retry-in-pipelinetask.md) | Specifying on-demand-retry in a PipelineTask | proposed | 2022-10-11 |
 |[TEP-0124](0124-distributed-tracing-for-tasks-and-pipelines.md) | Distributed tracing for Tasks and Pipelines | implementable | 2022-10-16 |
 |[TEP-0125](0125-add-credential-filter-to-entrypoint-logger.md) | Add credential filter to entrypoint logger | proposed | 2022-10-27 |
-|[TEP-0127](0127-larger-results-via-sidecar-logs.md) | Larger Results via Sidecar Logs | implementable | 2022-12-01 |
+|[TEP-0127](0127-larger-results-via-sidecar-logs.md) | Larger Results via Sidecar Logs | implemented | 2022-12-15 |


### PR DESCRIPTION
In this change, we mark [TEP-0127][tep-0127] as implemented. The implementation pull requests are [here][prs].

Thank you everyone for the contributions and reviews, and many many thanks to @chitrangpatel 👏🏾 

[tep-0127]: https://github.com/tektoncd/community/blob/main/teps/0127-larger-results-via-sidecar-logs.md
[prs]: https://github.com/tektoncd/pipeline/pulls?q=is%3Apr+tep-0127+