### PR TITLE
org: update maintainers team rights to "maintain"

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -190,7 +190,7 @@ orgs:
         - vinamra28
         privacy: closed
         repos:
-          catalog: write
+          catalog: maintain
       catlin.maintainers:
         description: the catlin maintainers
         maintainers:
@@ -201,7 +201,7 @@ orgs:
         - piyush-garg
         privacy: closed
         repos:
-          catlin: write
+          catlin: maintain
       chains.admins:
         description: the chains admins
         maintainers:
@@ -224,7 +224,7 @@ orgs:
         - lukehinds
         privacy: closed
         repos:
-          chains: write
+          chains: maintain
       cli.maintainers:
         description: the cli maintainers
         maintainers:
@@ -236,8 +236,8 @@ orgs:
         - vinamra28
         privacy: closed
         repos:
-          cli: write
-          homebrew-tools: write
+          cli: maintain
+          homebrew-tools: maintain
       core.maintainers:
         description: the core maintainers team (pipeline)
         maintainers:
@@ -253,7 +253,7 @@ orgs:
         - abayer
         privacy: closed
         repos:
-          pipeline: write
+          pipeline: maintain
       dashboard.maintainers:
         description: the dashboard maintainers
         maintainers:
@@ -265,7 +265,7 @@ orgs:
         - LyndseyBu
         privacy: closed
         repos:
-          dashboard: write
+          dashboard: maintain
       experimental.maintainers:
         description: the experimental maintainers
         maintainers:
@@ -280,7 +280,7 @@ orgs:
         - priyawadhwa
         privacy: closed
         repos:
-          experimental: write
+          experimental: maintain
       homebrew.maintainers:
         description: the homebrew-tools maintainers
         maintainers:
@@ -290,7 +290,7 @@ orgs:
         - danielhelfand
         privacy: closed
         repos:
-          homebrew-tools: write
+          homebrew-tools: maintain
       hub.maintainers:
         description: the hub maintainers
         maintainers:
@@ -303,7 +303,7 @@ orgs:
         - vinamra28
         privacy: closed
         repos:
-          hub: write
+          hub: maintain
       operator.maintainers:
         description: the operator maintainers
         maintainers:
@@ -318,7 +318,7 @@ orgs:
         - piyush-garg
         privacy: closed
         repos:
-          operator: write
+          operator: maintain
       plumbing.maintainers:
         description: the plumbing maintainers
         maintainers:
@@ -336,7 +336,7 @@ orgs:
         - wlynch
         privacy: closed
         repos:
-          plumbing: write
+          plumbing: maintain
       results.maintainers:
         description: the results maintainers
         maintainers:
@@ -351,7 +351,7 @@ orgs:
         - wlynch
         privacy: closed
         repos:
-          results: write
+          results: maintain
       results.collaborators:
         description: The results collaborators
         maintainers:
@@ -384,7 +384,7 @@ orgs:
         - savitaashture
         privacy: closed
         repos:
-          triggers: write
+          triggers: maintain
       website.maintainers:
         description: the website maintainers
         maintainers:
@@ -402,7 +402,7 @@ orgs:
         - geriom
         privacy: closed
         repos:
-          website: write
+          website: maintain
       core.collaborators:
         description: The core collaborators
         maintainers:
@@ -483,7 +483,7 @@ orgs:
         - pritidesai
         privacy: closed
         repos:
-          community: write
+          community: maintain
       community.collaborators:
         description: The community collaborators
         maintainers:
@@ -826,4 +826,4 @@ orgs:
         # sbwsg
         privacy: closed
         repos:
-          resolution: write
+          resolution: maintain


### PR DESCRIPTION
All maintainers team should have the "maintain" rights on the
repository they "maintain" instead of just write. It should allow them
to create tags and/or releases, etc (usually required for maintainer
doing a release).

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
