### PR TITLE
Add tektoncd-catalog org to org.yaml

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -828,3 +828,58 @@ orgs:
         privacy: closed
         repos:
           resolution: maintain
+  tektoncd-catalog:
+    admins:
+    - wlynch
+    - bobcatfish
+    - tekton-robot
+    - thelinuxfoundation
+    - vdemeester
+    - afrittoli
+    - dibyom
+    - QuanZhang-William
+    - vinamra28
+    billing_email: info@cd.foundation
+    company: ""
+    default_repository_permission: none
+    description: ""
+    email: ""
+    has_organization_projects: true
+    has_repository_projects: true
+    location: ""
+    name: ""
+    members:
+    - divyansh42
+    - iancoffey
+    - jerop
+    - jjasghar
+    - piyush-garg
+    - priyawadhwa
+    - PuneetPunamiya
+    - sm43
+    teams:
+      golang.maintainers:
+        description: The maintainers of golang catalog
+        members:
+        - vdemeester
+        - vinamra28
+        privacy: closed
+        repos:
+          golang: maintain
+      golang.collaborators:
+        description: The collaborators of golang catalog
+        maintainers:
+        - vdemeester
+        - vinamra28
+        members:
+        - divyansh42
+        - iancoffey
+        - jjasghar
+        - piyush-garg
+        - PuneetPunamiya
+        - sm43
+        - QuanZhang-William
+        privacy: closed
+        repos:
+          golang: read
+          


### PR DESCRIPTION
Part of [#889][#889]. This commit add the `tektoncd-catalog` to the `org.yaml` file so that the org, org member, team and team members can be automatically managed by Peribolos (which lets `tektoncd-catalog` org reaches the same level of automation as `tektoncd`).

The role assignment can be only done for the members that have already joined the new org. The role is assigned to each individual based on his/her current role in `tektoncd/catalog` repo.

This commit only adds teams for the [golang][golang] repo as the migration of the repo is under going. More teams will be added in later PRs once we start the migration for other Verified Catalogs.

[golang]: https://github.com/tektoncd-catalog/golang
[#889]: #889