### PR TITLE
Contributing to Milestones

### DIFF
--- a/standards.md
+++ b/standards.md
@@ -38,6 +38,8 @@ _See also [the Tekton review process](https://github.com/tektoncd/community/blob
     * Please refer the [release-note](#release-notes) section for more details.
 * Add the related [TEP-XXXX] at the beginning of a PR subject line
   * Consider adding the links of the related TEP, Feature Request thread, and related other implementation PRs
+* Add the Milestones to the pull request or the issue
+  * For tracking the status of each Milestone, please link to the Milestones if the pull request or the issue targets specific releases.
 
 ## Release Notes
 


### PR DESCRIPTION
As discussed in the WG, this commit adds to the guidelines that milestones should be added to the Pull Requests or Issues that target specific releases.

Thanks @pritidesai 