### PR TITLE
TEP-0096: Document features that became stable during transition

### DIFF
--- a/teps/0096-pipelines-v1.md
+++ b/teps/0096-pipelines-v1.md
@@ -285,6 +285,14 @@ and `taskRun.spec.sidecarOverrides` to `taskRun.spec.sidecarSpecs`, as it is mor
 - Rename TaskRun's `status.taskResults` to `status.results` and PipelineRun's `status.pipelineResults` to `status.results`
 to reduce redundancy. (v1beta1 TaskRun also has `status.resourceResults`, but this will not be present in v1 due to the
 deprecation of PipelineResources.)
+- There were several features that were promoted from alpha to stable when the V1 CRDs release was in progress, and 
+  these features will remain stable in V1 (instead of beta):
+  - [CSI Volumes](https://github.com/tektoncd/pipeline/blob/f1b68123b2de6c5fe05b0db3a98ca77b56e8a91f/docs/workspaces.md#csi)
+  - [Projected Volumes](https://github.com/tektoncd/pipeline/blob/f1b68123b2de6c5fe05b0db3a98ca77b56e8a91f/docs/workspaces.md#projected)
+  - [Propagated Parameters](./0107-propagating-parameters.md)
+  
+  Now that V1 CRDs have been released and beta feature flag is available, all features have to be promoted from alpha
+  to beta to stable.
 
 #### Deprecations
 


### PR DESCRIPTION
There are features that became "stable" after TEP-0096 was implementable but before V1 CRDs were released and "beta" feature flag was introduced in v0.43:
- CSI Volumes
- Projected Volumes
- Propagated Parameters

These features have been guarded behind the "stable" feature flag in two releases with V1 CRDs - v0.43 and v0.44. During the API WG on 01/23, we agreed to officially promote these features to "stable".

Now that V1 CRDs have been released and "beta" feature flag is available, all features have to be promoted from alpha to beta to stable.

/kind tep