### PR TITLE
Add jkandasa to the org

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -88,6 +88,7 @@ orgs:
     - jessm12
     - jinchihe
     - jjasghar
+    - jkandasa
     - jkutner
     - jlpettersson
     - jmcshane


### PR DESCRIPTION
Jeeva Kandasamy is part of the Red Hat team working on OpenShift Pipelines and thus on tektoncd components.

Membership is endorsed by existing contributors @vdemeester @piyush-garg @concaf

/cc @abayer @afrittoli @jerop 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>