### PR TITLE
Move inactive Pipelines reviewers to alumni

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -417,38 +417,27 @@ orgs:
         maintainers:
         - bobcatfish
         members:
-        - savitaashture
-        - barthy1
-        - FogDong
         - waveywaves
         - sthaha
         - abayer
         - shashwathi
         - skaegi
         - nader-ziada
-        - AlanGreene
         - wlynch
         - dlorenc
         - dibbles
         - pritidesai
         - jerop
-        - GregDritschler
         - danielhelfand
         - jlpettersson
         - dibyom
-        - Peaorl
         - piyush-garg
         - chmouel
         - psschwei
         - hrishin
         - ImJasonH
-        - EliZucker
         - vdemeester
         - mattmoor
-        - dwnusbaum
-        - othomann
-        - houshengbo
-        - vincent-pli
         - withlin
         - afrittoli
         - pierretasci
@@ -458,7 +447,18 @@ orgs:
         - chuangw6
         - XinruZhang
         # alumni:
+        # AlanGreene
+        # barthy1
+        # dwnusbaum
+        # EliZucker
+        # FogDong
+        # GregDritschler
+        # houshengbo
+        # othomann
+        # Peaorl
+        # savitaashture
         # sbwsg
+        # vincent-pli
         privacy: closed
         repos:
           pipeline: read


### PR DESCRIPTION
The contributor ladder states that contributors may be moved to emeritus status [due to extended periods of inactivity](https://github.com/tektoncd/community/blob/main/process/contributor-ladder.md#inactivity). This commit moves Pipelines reviewers with < 5 reviews ever and 0 reviews in 2022 (based on https://gist.github.com/afrittoli/8aa0e878a87652f785bb9e5ec4c98400) to alumni status.
This will help prevent Pipelines pull-requests from being auto-assigned to inactive contributors.

To those who have been moved to alumni status, thank you for your contributions to this project, and you are welcome to return to active reviewer status at any time.