### PR TITLE
Move inactive Pipelines reviewers to alumni (part 2)

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -417,47 +417,47 @@ orgs:
         maintainers:
         - bobcatfish
         members:
-        - waveywaves
-        - sthaha
         - abayer
-        - shashwathi
-        - skaegi
-        - nader-ziada
-        - wlynch
-        - dlorenc
-        - dibbles
-        - pritidesai
-        - jerop
+        - afrittoli
+        - chuangw6
         - danielhelfand
-        - jlpettersson
+        - dibbles
         - dibyom
-        - piyush-garg
-        - chmouel
-        - psschwei
+        - dlorenc
         - hrishin
         - ImJasonH
-        - vdemeester
-        - mattmoor
-        - withlin
-        - afrittoli
-        - pierretasci
+        - jerop
         - lbernick
+        - mattmoor
+        - piyush-garg
+        - pritidesai
+        - psschwei
+        - skaegi
+        - vdemeester
+        - waveywaves
+        - withlin
+        - wlynch
+        - XinruZhang
         - ywluogg
         - Yongxuanzhang
-        - chuangw6
-        - XinruZhang
         # alumni:
         # AlanGreene
         # barthy1
+        # chmouel
         # dwnusbaum
         # EliZucker
         # FogDong
         # GregDritschler
         # houshengbo
+        # jlpettersson
+        # nader-ziada
         # othomann
         # Peaorl
+        # pierretasci
         # savitaashture
         # sbwsg
+        # shashwathi
+        # sthaha
         # vincent-pli
         privacy: closed
         repos:


### PR DESCRIPTION
The contributor ladder states that contributors may be moved to emeritus status due to extended periods of inactivity. This commit moves Pipelines reviewers with no reviews in 2022 to alumni, and alphabetizes the list of current reviewers.

To those who have been moved to alumni status, thank you for your contributions to this project, and you are welcome to return to active reviewer status at any time.