### PR TITLE
Add khrm, sayan and enarha to Results Maintainers

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -354,6 +354,9 @@ orgs:
         - alan-ghelardi
         - dibyom
         - ImJasonH
+        - khrm
+        - sayan-biswas
+        - enarha
         - wlynch
         privacy: closed
         repos:


### PR DESCRIPTION
I am doing the release, so I need to be a member of the maintainers team in results. I need access to release notes. Same with other members, they will probably do the release in future.