### PR TITLE
TEP-0011: Redirecting Step Output Streams - Mark as Implemented

### DIFF
--- a/teps/0011-redirecting-step-output-streams.md
+++ b/teps/0011-redirecting-step-output-streams.md
@@ -3,8 +3,8 @@ title: redirecting-step-output-streams
 authors:
   - "@chhsia0"
 creation-date: 2020-08-17
-last-updated: 2020-11-02
-status: implementable
+last-updated: 2023-03-21
+status: implemented
 ---
 
 # TEP-0011: Redirecting Step Output Streams
@@ -219,3 +219,5 @@ A proof-of-concept implementation is presented in [tektoncd/pipeline#3103](https
 * Make it possible to extract results from a container's stdout ([tektoncd/pipeline#2925](https://github.com/tektoncd/pipeline/issues/2925)).
 
 * Added `-stdout_file` and `-stderr_file` flags to entrypoint ([tektoncd/pipeline#3103](https://github.com/tektoncd/pipeline/pull/3103)).
+
+* Implementation: https://github.com/tektoncd/pipeline/pull/4882

--- a/teps/README.md
+++ b/teps/README.md
@@ -16,7 +16,7 @@ This is the complete list of Tekton TEPs:
 |[TEP-0008](0008-support-knative-service-for-triggers-eventlistener-pod.md) | Support Knative Service for Triggers EventListener Pod | implemented | 2020-08-25 |
 |[TEP-0009](0009-trigger-crd.md) | Trigger CRD | implemented | 2020-09-08 |
 |[TEP-0010](0010-optional-workspaces.md) | Optional Workspaces | implemented | 2020-10-15 |
-|[TEP-0011](0011-redirecting-step-output-streams.md) | redirecting-step-output-streams | implementable | 2020-11-02 |
+|[TEP-0011](0011-redirecting-step-output-streams.md) | redirecting-step-output-streams | implemented | 2023-03-21 |
 |[TEP-0012](0012-api-spec.md) | API Specification | implemented | 2021-12-14 |
 |[TEP-0014](0014-step-timeout.md) | Step Timeout | implemented | 2021-12-13 |
 |[TEP-0015](0015-pending-pipeline.md) | pending-pipeline-run | implemented | 2020-09-10 |


### PR DESCRIPTION
TEP-0011 was implemented in https://github.com/tektoncd/pipeline/pull/4882. This change updates the TEP state from `implementable` to `implemented`.

/kind tep