### PR TITLE
TEP-0027: HTTPS Connection To Triggers EventListener - Mark as Implemented

### DIFF
--- a/teps/0027-https-connection-to-triggers-eventlistener.md
+++ b/teps/0027-https-connection-to-triggers-eventlistener.md
@@ -3,8 +3,8 @@ title: HTTPS Connection to Triggers EventListener
 authors:
   - "@savitaashture"
 creation-date: 2020-10-19
-last-updated: 2020-11-01
-status: implementable
+last-updated: 2023-03-21
+status: implemented
 ---
 
 # TEP-0027: HTTPS Connection To Triggers EventListener
@@ -152,3 +152,4 @@ At high level below are few implementation details
 
 ## References 
 1. GitHub issue: https://github.com/tektoncd/triggers/issues/650
+2. Implementation: https://github.com/tektoncd/triggers/pull/819

--- a/teps/README.md
+++ b/teps/README.md
@@ -29,7 +29,7 @@ This is the complete list of Tekton TEPs:
 |[TEP-0024](0024-embedded-trigger-templates.md) | Embedded TriggerTemplates | implemented | 2020-10-01 |
 |[TEP-0025](0025-hermekton.md) | Hermetic Builds | implementable | 2020-09-11 |
 |[TEP-0026](0026-interceptor-plugins.md) | interceptor-plugins | implemented | 2020-10-08 |
-|[TEP-0027](0027-https-connection-to-triggers-eventlistener.md) | HTTPS Connection to Triggers EventListener | implementable | 2020-11-01 |
+|[TEP-0027](0027-https-connection-to-triggers-eventlistener.md) | HTTPS Connection to Triggers EventListener | implemented | 2023-03-21 |
 |[TEP-0028](0028-task-execution-status-at-runtime.md) | task-exec-status-at-runtime | implemented | 2021-06-03 |
 |[TEP-0029](0029-step-workspaces.md) | step-and-sidecar-workspaces | implemented | 2022-07-22 |
 |[TEP-0030](0030-workspace-paths.md) | workspace-paths | proposed | 2020-10-18 |


### PR DESCRIPTION
TEP-0027 was implemented in https://github.com/tektoncd/triggers/pull/819. This change updates the TEP state from `implementable` to `implemented`.