### PR TITLE
[TEP-0133] Mark TEP-0133 as implemented

### DIFF
--- a/teps/0133-configure-default-resolver.md
+++ b/teps/0133-configure-default-resolver.md
@@ -1,8 +1,8 @@
 ---
-status: implementable
+status: implemented
 title: Configure Default Resolver
 creation-date: '2023-03-03'
-last-updated: '2023-03-03'
+last-updated: '2023-03-21'
 authors:
 - '@QuanZhang-William'
 - '@vdemeester'
@@ -26,6 +26,7 @@ collaborators: []
   - [Flexibility](#flexibility)
   - [Reusability](#reusability)
 - [Alternatives](#alternatives)
+- [Implementation PRs](#implementation-prs)
 - [References](#references)
 <!-- /toc -->
 
@@ -191,6 +192,10 @@ Instead of setting the default `Resolver` in the [config-defaults.yaml][config-d
 However, the [resolver feature flag] resides in the `tekton-pipelines-resolver` namespace instead of the `tekton-pipelines` namespace. This alternative introduces an extra dependency to the `tekton-pipelines-resolver` namespace for *Tekton Webhooks and Controllers* while bringing no extra benefit.
 
 We can revisit this alternative if we decide to merge the `tekton-pipelines-resolver` back to the `tekton-pipelines` namespace in the future.
+
+## Implementation PRs
+- [Configure default resolver](https://github.com/tektoncd/pipeline/pull/6317)
+- [Refactor set default test helper](https://github.com/tektoncd/pipeline/pull/6339)
 
 ## References
 - [TEP-0060: Remote Resolution][TEP-0060]

--- a/teps/README.md
+++ b/teps/README.md
@@ -121,4 +121,4 @@ This is the complete list of Tekton TEPs:
 |[TEP-0129](0129-multiple-tekton-instances-per-cluster.md) | Multiple Tekton instances per cluster | proposed | 2023-01-11 |
 |[TEP-0130](0130-pipeline-level-service.md) | Pipeline-level Service | proposed | 2023-02-21 |
 |[TEP-0131](0131-tekton-conformance-policy.md) | Tekton Conformance Policy | proposed | 2023-02-14 |
-|[TEP-0133](0133-configure-default-resolver.md) | Configure Default Resolver | implementable | 2023-03-03 |
+|[TEP-0133](0133-configure-default-resolver.md) | Configure Default Resolver | implemented | 2023-03-21 |


### PR DESCRIPTION
This commit updates the TEP-0133 to `implemented` state with implementation PRs.

/kind tep