### PR TITLE
TEP-0105: Remove Pipeline v1alpha1 API - Mark as Implemented

### DIFF
--- a/teps/0105-remove-pipeline-v1alpha1-api.md
+++ b/teps/0105-remove-pipeline-v1alpha1-api.md
@@ -1,8 +1,8 @@
 ---
-status: implementable
+status: implemented
 title: Remove Pipeline v1alpha1 API
 creation-date: '2022-04-11'
-last-updated: '2022-05-17'
+last-updated: '2023-03-21'
 authors:
 - '@abayer'
 ---
@@ -82,3 +82,7 @@ some lurking references to `v1alpha1` which should be removed. Documentation
 relating to migrating from `v1alpha1` to `v1beta1` will remain.
 
 Projects downstream of Pipeline will be responsible for updating their own code.
+
+## References
+
+- Implementation: https://github.com/tektoncd/pipeline/pull/5005

--- a/teps/README.md
+++ b/teps/README.md
@@ -96,7 +96,7 @@ This is the complete list of Tekton TEPs:
 |[TEP-0102](0102-https-connection-to-triggers-interceptor.md) | HTTPS Connection to Triggers ClusterInterceptor | implemented | 2022-04-20 |
 |[TEP-0103](0103-skipping-reason.md) | Skipping Reason | implemented | 2022-05-05 |
 |[TEP-0104](0104-tasklevel-resource-requirements.md) | Task-level Resource Requirements | implemented | 2022-08-16 |
-|[TEP-0105](0105-remove-pipeline-v1alpha1-api.md) | Remove Pipeline v1alpha1 API | implementable | 2022-05-17 |
+|[TEP-0105](0105-remove-pipeline-v1alpha1-api.md) | Remove Pipeline v1alpha1 API | implemented | 2023-03-21 |
 |[TEP-0106](0106-support-specifying-metadata-per-task-in-runtime.md) | Support Specifying Metadata per Task in Runtime | implemented | 2022-05-27 |
 |[TEP-0107](0107-propagating-parameters.md) | Propagating Parameters | implemented | 2022-05-26 |
 |[TEP-0108](0108-mapping-workspaces.md) | Mapping Workspaces | implemented | 2022-05-26 |


### PR DESCRIPTION
TEP-0105 was implemented in https://github.com/tektoncd/pipeline/pull/5005. This change updates the TEP state from `implementable` to `implemented`.