### PR TITLE
TEP-0074: Deprecate PipelineResources - Mark as Implemented

### DIFF
--- a/teps/0074-deprecate-pipelineresources.md
+++ b/teps/0074-deprecate-pipelineresources.md
@@ -1,8 +1,8 @@
 ---
-status: implementable
+status: implemented
 title: Deprecate PipelineResources
 creation-date: '2021-07-14'
-last-updated: '2022-04-11'
+last-updated: '2023-03-21'
 authors:
 - '@bobcatfish'
 - '@lbernick'
@@ -382,6 +382,7 @@ _See details in [Proposal](#proposal)_
 ## Implementation Pull request(s)
 
 - [Mark PipelineResources as deprecated](https://github.com/tektoncd/pipeline/pull/4376)
+- [Removal of PipelineResources](https://github.com/tektoncd/pipeline/pulls?q=is%3Apr+author%3AJeromeJu+is%3Aclosed+tep074)
 
 ## References
 

--- a/teps/README.md
+++ b/teps/README.md
@@ -69,7 +69,7 @@ This is the complete list of Tekton TEPs:
 |[TEP-0071](0071-custom-task-sdk.md) | Custom Task SDK | proposed | 2021-06-15 |
 |[TEP-0072](0072-results-json-serialized-records.md) | Results: JSON Serialized Records | implementable | 2021-07-26 |
 |[TEP-0073](0073-simplify-metrics.md) | Simplify metrics | implemented | 2022-02-28 |
-|[TEP-0074](0074-deprecate-pipelineresources.md) | Deprecate PipelineResources | implementable | 2022-04-11 |
+|[TEP-0074](0074-deprecate-pipelineresources.md) | Deprecate PipelineResources | implemented | 2023-03-21 |
 |[TEP-0075](0075-object-param-and-result-types.md) | Object/Dictionary param and result types | implemented | 2022-09-26 |
 |[TEP-0076](0076-array-result-types.md) | Array result types | implemented | 2022-09-26 |
 |[TEP-0079](0079-tekton-catalog-support-tiers.md) | Tekton Catalog Support Tiers | implementable | 2023-01-12 |


### PR DESCRIPTION
PipelineResources have been removed - [PRs]. This change updates the TEP state from `implementable` to `implemented`.

/kind tep

[PRs]: https://github.com/tektoncd/pipeline/pulls?q=is%3Apr+author%3AJeromeJu+is%3Aclosed+tep074