### PR TITLE
TEP-0117: Tekton Results Logs - Mark as Implemented

### DIFF
--- a/teps/0117-tekton-results-logs.md
+++ b/teps/0117-tekton-results-logs.md
@@ -1,8 +1,8 @@
 ---
-status: implementable
+status: implemented
 title: Tekton Results Logs
 creation-date: '2022-07-19'
-last-updated: '2022-10-21'
+last-updated: '2023-03-22'
 authors:
 - '@adambkaplan'
 ---
@@ -362,3 +362,4 @@ It will be a quick reference for those looking for implementation of this TEP.
 - Initial proof of concept:
   [demo](https://www.youtube.com/watch?v=VVcLeEi9NL4),
   [code](https://github.com/tektoncd/results/pull/203)
+- Implementation: https://github.com/tektoncd/results/pull/301

--- a/teps/README.md
+++ b/teps/README.md
@@ -107,7 +107,7 @@ This is the complete list of Tekton TEPs:
 |[TEP-0114](0114-custom-tasks-beta.md) | Custom Tasks Beta | implemented | 2022-12-12 |
 |[TEP-0115](0115-tekton-catalog-git-based-versioning.md) | Tekton Catalog Git-Based Versioning | implemented | 2022-12-14 |
 |[TEP-0116](0116-referencing-finally-task-results-in-pipeline-results.md) | Referencing Finally Task Results in Pipeline Results | implemented | 2022-08-11 |
-|[TEP-0117](0117-tekton-results-logs.md) | Tekton Results Logs | implementable | 2022-10-21 |
+|[TEP-0117](0117-tekton-results-logs.md) | Tekton Results Logs | implemented | 2023-03-22 |
 |[TEP-0118](0118-matrix-with-explicit-combinations-of-parameters.md) | Matrix with Explicit Combinations of Parameters | implementable | 2022-08-08 |
 |[TEP-0119](0119-add-taskrun-template-in-pipelinerun.md) | Add taskRun template in PipelineRun | implementable | 2022-09-01 |
 |[TEP-0120](0120-canceling-concurrent-pipelineruns.md) | Canceling Concurrent PipelineRuns | proposed | 2022-09-23 |


### PR DESCRIPTION
TEP-0117 was implemented - https://github.com/tektoncd/results/pull/301. This change updates the TEP state from `implementable` to `implemented`.

/kind tep