### PR TITLE
Change deprecated Prow links

### DIFF
--- a/process/README.md
+++ b/process/README.md
@@ -117,10 +117,10 @@ the PR. (OWNERS, your review requests can be viewed at
 ### Pull request process
 
 Tekton repos use
-[Prow](https://github.com/kubernetes/test-infra/tree/master/prow) and related
+[Prow](https://docs.prow.k8s.io/docs/overview) and related
 tools like
-[Tide](https://github.com/kubernetes/test-infra/tree/master/prow/tide) and
-[Spyglass](https://github.com/kubernetes/test-infra/blob/master/prow/spyglass/README.md).
+[Tide](https://docs.prow.k8s.io/docs/components/core/tide) and
+[Spyglass](https://docs.prow.k8s.io/docs/spyglass).
 This means that automation will be applied to your pull requests.
 
 The configuration for this automation is in


### PR DESCRIPTION
Readme files in the Prow repo are marked as deprecated and it seems the files are overdue for deletion, they are about to disappear.

The changes point to migrated doc location.

---

For future reference, screenshot of current Prow repo Readmes:
![deprecation warning and deletion due](https://user-images.githubusercontent.com/8210848/228090783-0a3ebd3d-0f27-43f1-966f-a32a15ad9fff.png)
