### PR TITLE
Remove links to Workflows WG meetings

### DIFF
--- a/working-groups.md
+++ b/working-groups.md
@@ -302,21 +302,20 @@ This is the working group for [`tektoncd/chains`](https://github.com/tektoncd/ch
 
 ## Workflows
 
-Topics for this WG include the experimental [Tekton Workflows](https://github.com/tektoncd/experimental/tree/main/workflows), [Pipelines as Code](https://github.com/openshift-pipelines/pipelines-as-code), [Remote Resolution](https://github.com/tektoncd/community/blob/main/teps/0060-remote-resource-resolution.md) etc.
+Topics for this WG include the [Workflows TEP](./teps/0098-workflows.md), the experimental [Tekton Workflows project](https://github.com/tektoncd/experimental/tree/main/workflows),
+and RedHat's [Pipelines as Code](https://github.com/openshift-pipelines/pipelines-as-code).
 
 | Artifact                   | Link                                                                                                                                                                                                                                                                                                          |
 |----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Forum                      | [tekton-dev@](https://groups.google.com/forum/#!forum/tekton-dev)                                                                                                                                                                                                                                             |
-| Community Meeting VC       | [Zoom](https://zoom.us/j/95023453163?pwd=VVU1L1o2UWpxOURKbXpRVC9EaGtNdz09)                                                                                                                                                                                                                                    |
-| Community Meeting Calendar | Tuesdays every week, 10am -10:30am ET <br>[Calendar](https://calendar.google.com/event?action=TEMPLATE&tmeid=NDl0bzN1OWl2dWxlMXBpNGFnaDhjM2N2NjRfMjAyMTA5MDdUMTQwMDAwWiBnb29nbGUuY29tX2Qzb3Zjdm8xcDMyMTloOTg5NTczdjk4Zm5zQGc&tmsrc=google.com_d3ovcvo1p3219h989573v98fns%40group.calendar.google.com&scp=ALL) |
-| Meeting Notes              | [Notes](https://docs.google.com/document/d/1di4ikeVb8Mksgbq4CzW4m4xUQPZ2dQMLvK1VIJw7OQg/edit)                                                                                                                                                                                                                 |
+| Forum                      | [tekton-dev@](https://groups.google.com/forum/#!forum/tekton-dev)                                                                                                                                                                                                                                             |                                                                                                                                                                                                               |
 | Slack Channels             | [#workflows](https://tektoncd.slack.com/messages/workflows)                                                                                                                                                                                                                                                   |
 
-| &nbsp;                                                  | Facilitators     | Company | Profile                               |
-|---------------------------------------------------------|------------------|---------|---------------------------------------|
-| <img width="30px" src="https://github.com/dibyom.png">  | Dibyo Mukherjee  | Google  | [dibyom](https://github.com/dibyom)   |
-| <img width="30px" src="https://github.com/khrm.png">    | Khurram Baig     | Red Hat | [khrm](https://github.com/khrm)       |
-| <img width="30px" src="https://github.com/chmouel.png"> | Chmouel Boudjnah | Red Hat | [chmouel](https://github.com/chmouel) |
+| &nbsp;                                                   | Points of Contact | Company | Profile                                |
+|----------------------------------------------------------|-------------------|---------|--------------------------------------- |
+| <img width="30px" src="https://github.com/dibyom.png">   | Dibyo Mukherjee   | Google  | [dibyom](https://github.com/dibyom)    |
+| <img width="30px" src="https://github.com/khrm.png">     | Khurram Baig      | Red Hat | [khrm](https://github.com/khrm)        |
+| <img width="30px" src="https://github.com/chmouel.png">  | Chmouel Boudjnah  | Red Hat | [chmouel](https://github.com/chmouel)  |
+| <img width="30px" src="https://github.com/lbernick.png"> | Lee Bernick       | Google  | [lbernick](https://github.com/lbernick)|
 
 ## Pipeline
 


### PR DESCRIPTION
While Workflows is still an active area of interest, and the TEP is in "proposed" state,
Workflows WG is no longer actively meeting. This commit removes the meeting links from
the calendar, but maintains the link to the slack channel and points of contact.