### PR TITLE
Tep-0097 breakpoint change `onFailure` type string to boolean

### DIFF
--- a/teps/0097-breakpoints-for-taskruns-and-pipelineruns.md
+++ b/teps/0097-breakpoints-for-taskruns-and-pipelineruns.md
@@ -75,7 +75,7 @@ which the user plans on debugging.
 ```yaml
   debug:
     breakpoints:
-      onFailure: "enabled"
+      onFailure: true
       beforeSteps: ["test-js"]
       afterSteps: ["push-to-registry"]
       
@@ -130,7 +130,7 @@ In the process of debugging a TaskRun, there shouldn't be any interruption. To e
   debug:
     timeout: "120"
     breakpoints:
-      onFailure: "enabled"
+      onFailure: true
       beforeSteps: ["test-js"]
       afterSteps: ["push-to-registry"]
       
@@ -172,7 +172,7 @@ metadata:
 spec:
   debug:
     breakpoints:
-        onFailure: "enabled"
+        onFailure: true
         beforeTasks: ["task-build-archive"]
         afterTasks: ["deploy-frontend"]
 ```
@@ -231,7 +231,7 @@ metadata:
 spec:
   debug:
     breakpoints:
-      onFailure: "enabled"
+      onFailure: true
 ```
 
 ### PipelineRun Timeout Implications
@@ -243,7 +243,7 @@ In the process of debugging a PipelineRun, there shouldn't be any interruption. 
   debug:
     timeout: "120"
     breakpoints:
-      onFailure: "enabled"
+      onFailure: true
       beforeTasks: ["task-build-archive"]
       afterTasks: ["deploy-frontend"]
       
@@ -267,7 +267,7 @@ The scenario below provides details on what the user should do to debug their fa
    spec:
     debug: 
       breakpoint: 
-        onFailure: "enabled"
+        onFailure: true
    ```
 3. Once the TaskRun is created and a step fails, the TaskRun Pod will be in the Running state. Till that time the CLI will wait 
    for the TaskRun to stop executing (due to failure) and go into the limbo state which would be leveraged for debugging.
@@ -280,7 +280,7 @@ The scenario below provides details on what the user should do to debug their fa
     ```yaml
     debug:
       breakpoints: 
-        onFailure: "enabled"
+        onFailure: true
         beforeSteps: []
         afterSteps: []
     ```


### PR DESCRIPTION
breakpoint change `onFailure` type string to boolean,make it more intuitive whether to enable `onFailure`

As described in TEP-0097 when enabling the `onFailure` breakpoint, set to true to enable breakpoint-ing on failure
https://github.com/tektoncd/community/blob/b8ae0c60a42486e5a8e061a7377eaf3b46e0104d/teps/0097-breakpoints-for-taskruns-and-pipelineruns.md?plain=1#L84-L87