### PR TITLE
Cleanup org.yaml for chains groups.

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -209,16 +209,16 @@ orgs:
           catlin: maintain
       chains.admins:
         description: the chains admins
-        maintainers:
-        - lcarva
-        - priyawadhwa
-        - wlynch
+        members:
+          - lcarva
+          - priyawadhwa
+          - wlynch
         privacy: closed
         repos:
           chains: admin
       chains.maintainers:
         description: the chains maintainers
-        maintainers:
+        members:
         - lcarva
         - priyawadhwa
         - wlynch
@@ -794,10 +794,6 @@ orgs:
           catlin: read
       chains.collaborators:
         description: The chains collaborators
-        maintainers:
-        - lcarva
-        - priyawadhwa
-        - wlynch
         members:
         - abayer
         - afrittoli
@@ -806,10 +802,13 @@ orgs:
         - chitrangpatel
         - dlorenc
         - ImJasonH
+        - lcarva
         - loosebazooka
         - mattmoor
         - pritidesai
+        - priyawadhwa
         - vdemeester
+        - wlynch
         privacy: closed
         repos:
           chains: read

--- a/org/org.yaml
+++ b/org/org.yaml
@@ -539,6 +539,7 @@ orgs:
         - pierretasci
         - priyawadhwa
         - lbernick
+        - lcarva
         # alumni:
         # sbwsg
         privacy: closed

--- a/org/org.yaml
+++ b/org/org.yaml
@@ -210,6 +210,7 @@ orgs:
       chains.admins:
         description: the chains admins
         maintainers:
+        - lcarva
         - priyawadhwa
         - wlynch
         privacy: closed
@@ -218,16 +219,9 @@ orgs:
       chains.maintainers:
         description: the chains maintainers
         maintainers:
-        - vdemeester
-        - dlorenc
+        - lcarva
         - priyawadhwa
         - wlynch
-        - lcarva
-        members:
-        - mpeters
-        - skelterjohn
-        - font
-        - lukehinds
         privacy: closed
         repos:
           chains: maintain
@@ -800,20 +794,21 @@ orgs:
       chains.collaborators:
         description: The chains collaborators
         maintainers:
+        - lcarva
+        - priyawadhwa
+        - wlynch
+        members:
         - abayer
         - afrittoli
         - bobcatfish
-        - ImJasonH
-        - vdemeester
-        - wlynch
-        members:
         - chuangw6
         - chitrangpatel
         - dlorenc
-        - lcarva
+        - ImJasonH
         - loosebazooka
         - mattmoor
         - pritidesai
+        - vdemeester
         privacy: closed
         repos:
           chains: read


### PR DESCRIPTION
Primarily removes inactive users from maintainer ACL and matches admin permissions to current maintainers.

/cc @lcarva - also added you to community.collaborators so you can lgtm PRs like this)

/cc @chuangw6 - saw the agenda item you added to the chains wg - hopefully this clears things up.