### PR TITLE
Add design principles on CustomRun API

### DIFF
--- a/design-principles.md
+++ b/design-principles.md
@@ -25,6 +25,10 @@
 1. [Avoid implementing templating logic](https://docs.google.com/document/d/1h_3vSApIsuiwGkrqSiegi4NVaYG4oVzBquGAhIN6qGM/edit#heading=h.6kxvcvm7rs3r); prefer variable replacement.
 1. Avoid implementing our own expression syntax; when required prefer existing languages which are widely used and include supporting development tools.
 1. In TEPs, discuss how the proposal affects the flexibility of Tekton and demonstrate that any specific/opinionated choices are necessary but extensible. 
+1. Before adding an optional field to the spec or status of `CustomRun`, consider
+whether it could be part of the custom spec or custom status instead.
+New fields should be added to the spec or status of the `CustomRun` API only if they
+make sense for all custom run controllers to support.
 
 ## Conformance
 1. Tekton features should work as the user expects in varied environment setup.


### PR DESCRIPTION
CustomRun is different from other Tekton APIs because its API is implemented by custom run controllers, rather than in-tree controllers. Therefore, adding new fields to this API should be done with extra caution. This commit adds a design principle providing guidance on whether a new field should go in the CustomRun API or left to custom run controllers to support as part of the custom spec or custom status, based on whether a feature is applicable to all CustomRuns or just a feature of some of them.