### PR TITLE
Fix broken Docs links in standards.md

### DIFF
--- a/standards.md
+++ b/standards.md
@@ -28,7 +28,7 @@ Each Pull Request is expected to meet the following expectations around:
   * [Tests](#tests)
   * [Reconciler/Controller Changes](#reconcilercontroller-changes)
 
-_See also [the Tekton review process](https://github.com/tektoncd/community/blob/main/process.md#reviews)._
+_See also [the Tekton review process](https://github.com/tektoncd/community/blob/main/process/README.md#reviews)._
 
 ## Reviewer Responsibilities
 

--- a/standards.md
+++ b/standards.md
@@ -218,8 +218,8 @@ PRs must adhere to the project's API stability policy.
 * Include Markdown doc updates for user visible features
 * Spelling and grammar should be correct
 * Try to make formatting look as good as possible (use preview mode to check)
-* Follow [content](https://github.com/tektoncd/website/blob/main/content/en/doc-con-content.md)
-  and [formatting](https://github.com/tektoncd/website/blob/main/content/en/doc-con-formatting.md) guidelines
+* Follow [content](https://github.com/tektoncd/website/blob/main/content/en/docs/Contribute/doc-con-content.md)
+  and [formatting](https://github.com/tektoncd/website/blob/main/content/en/docs/Contribute/doc-con-formatting.md) guidelines
 * Should explain thoroughly how the new feature works
 * If possible, in addition to code snippets, include a reference to an end to end example
 * Ensure that all links and references are valid


### PR DESCRIPTION
PR to update the links in the standards.md file for contributors

**_Release notes:_**
```release-note
NONE
```
Minor docs change