### PR TITLE
Update operator's owners to be in sync with the repository

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -310,13 +310,11 @@ orgs:
         maintainers:
         - vdemeester
         members:
-        - houshengbo
-        - nikhil-thomas
-        - vincent-pli
         - savitaashture
         - sm43
         - concaf
         - piyush-garg
+        - jkandasa
         privacy: closed
         repos:
           operator: maintain
@@ -508,6 +506,7 @@ orgs:
         - eddycharly
         - skaegi
         - pradeepitm12
+        - jkandasa
         - khrm
         - pratap0007
         - kimsterv
@@ -732,14 +731,11 @@ orgs:
         - ImJasonH
         - vdemeester
         members:
-        - houshengbo
-        - nikhil-thomas
-        - pradeepitm12
         - savitaashture
-        - vincent-pli
         - piyush-garg
         - concaf
         - jkandasa
+        - PuneetPunamiya
         privacy: closed
         repos:
           operator: read


### PR DESCRIPTION
See https://github.com/tektoncd/operator/pull/1536:

- Add @jkandasa as a maintainer
- Add @PuneetPunamiya as a reviewer
- Remove inactive users from maintainers/reviewers

/cc @afrittoli @jerop @piyush-garg @PuneetPunamiya @jkandasa 