### PR TITLE
[TEP-0135] Rename coscheduling feature flag values

### DIFF
--- a/teps/README.md
+++ b/teps/README.md
@@ -124,4 +124,4 @@ This is the complete list of Tekton TEPs:
 |[TEP-0132](0132-queueing-concurrent-runs.md) | Queueing Concurrent Runs | proposed | 2023-03-20 |
 |[TEP-0133](0133-configure-default-resolver.md) | Configure Default Resolver | implemented | 2023-03-21 |
 |[TEP-0134](0134-concise-pipelines.md) | Concise Pipelines | proposed | 2023-04-28 |
-|[TEP-0135](0135-coscheduling-pipelinerun-pods.md) | Coscheduling PipelineRun pods | implementable | 2023-06-08 |
+|[TEP-0135](0135-coscheduling-pipelinerun-pods.md) | Coscheduling PipelineRun pods | implementable | 2023-06-22 |


### PR DESCRIPTION
This commit updates the values of the `coscheduling` feature flag from `coschedule-workspaces` and `coschedule-pipelineruns` to `workspaces` and `pipelineruns` respectively to make the values more concise.

/kind tep