### PR TITLE
Make chitrangpatel a Chains maintainer

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -220,6 +220,7 @@ orgs:
       chains.maintainers:
         description: the chains maintainers
         members:
+        - chitrangpatel
         - chuangw6
         - lcarva
         - priyawadhwa
@@ -895,4 +896,4 @@ orgs:
         privacy: closed
         repos:
           golang: read
-          
+


### PR DESCRIPTION
@chitrangpatel has been involved in the Tekton Chains project for at least 6 months. He has made several contributions. Most recently, he is driving the design and implementation of producing SLSA Provenance v1.0. This has resulted in numerous PRs, design docs, and discussions. He has provided [144 PR comments in the last 3 months](https://tekton.devstats.cd.foundation/d/46/pr-reviews-by-contributor?orgId=1&var-period=d&var-repo_name=tektoncd%2Fchains&var-reviewers=%22chitrangpatel%22&from=1682049600000&to=1689998399000) across [25 PRs](https://github.com/tektoncd/chains/pulls?q=is%3Apr+reviewed-by%3Achitrangpatel+).

The number of PRs is lower than the required 30. However, Chains has a lower rate of changes than tektoncd/pipeline, for example. He is just as active as the existing maintainers. (NOTE: dependabot updates could be used to raise the number of PRs reviewed. However, there's little value in a non-maintainer reviewing those IMO.)