### PR TITLE
Add chitrang as community collaborator

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -557,6 +557,7 @@ orgs:
         - lbernick
         - lcarva
         - adambkaplan
+        - chitrangpatel
         # alumni:
         # sbwsg
         privacy: closed


### PR DESCRIPTION
When another member tried to assign me as a reviewer to the TEP, the bot rejected it with the [message](https://github.com/tektoncd/community/pull/1055#issuecomment-1753310644.).

This PR fixes that by adding @chitrangpatel as a community collaborator.