### PR TITLE
Add Chitrang to TEP owners to grant approval privileges

### DIFF
--- a/teps/OWNERS
+++ b/teps/OWNERS
@@ -7,6 +7,7 @@ approvers:
 - alangreene
 - bobcatfish
 - chetan-rns
+- chitrangpatel
 - chmouel
 - danielhelfand
 - dibbles


### PR DESCRIPTION
This PR adds Chitrang to `tep/OWNERS`.

While reviewing https://github.com/tektoncd/community/pull/1044, I was unable to `approve` it with the slash command. 
I was encouraged by several maintainers to add myself as an Owner of TEPs since I have been actively engaging in designs.