### PR TITLE
remove loosebazooka

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -105,7 +105,6 @@ orgs:
     - kimsterv
     - lcarva
     - lbernick
-    - loosebazooka
     - lukehinds
     - maneeshmehra
     - marcelmue
@@ -825,7 +824,6 @@ orgs:
         - dlorenc
         - ImJasonH
         - lcarva
-        - loosebazooka
         - mattmoor
         - pritidesai
         - priyawadhwa


### PR DESCRIPTION
loosebazooka is not active, and does not plan to be for the foreseeable future