### PR TITLE
[TEP-0144] Param Subset Enforcement

### DIFF
--- a/teps/README.md
+++ b/teps/README.md
@@ -133,6 +133,6 @@ This is the complete list of Tekton TEPs:
 |[TEP-0141](0141-platform-context-variables.md) | Platform Context Variables | proposed | 2023-08-21 |
 |[TEP-0142](0142-enable-step-reusability.md) | Enable Step Reusability | implementable | 2023-09-14 |
 |[TEP-0143](0143-concise-parameters-results.md) | Concise Parameters and Results | proposed | 2023-10-01 |
-|[TEP-0144](0144-param-enum.md) | Param Enum | implementable | 2023-09-20 |
+|[TEP-0144](0144-param-enum.md) | Param Enum | implementable | 2023-11-10 |
 |[TEP-0145](0145-cel-in-whenexpression.md) | CEL in WhenExpression | implemented | 2023-10-22 |
 |[TEP-0146](0146-parameters-in-script.md) | Parameters in Script | proposed | 2023-10-02 |


### PR DESCRIPTION
Prior to this commit, Tekton validates the intersection of the enums that are both specified at `Pipeline` level and at the referenced `PipelineTask` level. In this solution, users are burdened with calculating intersections by iterating through all the PipelineTasks.

This commits add an extra validation to require that the pipeline-level enum must be a subset of the corresponding pipeline-task level enum. With this approach, users only need to check the pipeline-level enum to execute the pipeline successfully.

/kind tep