### PR TITLE
Update usage of StepResults with StepActions

### DIFF
--- a/teps/README.md
+++ b/teps/README.md
@@ -131,7 +131,7 @@ This is the complete list of Tekton TEPs:
 |[TEP-0139](0139-trusted-artifacts.md) | Trusted Artifacts | proposed | 2023-07-27 |
 |[TEP-0140](0140-producing-results-in-matrix.md) | Producing Results in Matrix | implemented | 2023-10-24 |
 |[TEP-0141](0141-platform-context-variables.md) | Platform Context Variables | proposed | 2023-08-21 |
-|[TEP-0142](0142-enable-step-reusability.md) | Enable Step Reusability | implementable | 2023-09-14 |
+|[TEP-0142](0142-enable-step-reusability.md) | Enable Step Reusability | implementable | 2023-11-20 |
 |[TEP-0143](0143-concise-parameters-results.md) | Concise Parameters and Results | proposed | 2023-10-01 |
 |[TEP-0144](0144-param-enum.md) | Param Enum | implementable | 2023-11-10 |
 |[TEP-0145](0145-cel-in-whenexpression.md) | CEL in WhenExpression | implemented | 2023-10-22 |


### PR DESCRIPTION
Prior to this, the TEP did not go into details of the use of `StepResults` in inlined step. For consistency with `StepActions`, this PR includes the use of `StepResults` for inlined Steps as well.

This is a PR following consensus in the API WG on Nov 20, 2023.

/kind tep