### PR TITLE
StepActions Catalog

### DIFF
--- a/teps/0003-tekton-catalog-organization.md
+++ b/teps/0003-tekton-catalog-organization.md
@@ -4,8 +4,10 @@ authors:
   - "@vdemeester"
   - "@sthaha"
   - "@bobcatfish"
+contributors:
+  - "@chitrangpatel"
 creation-date: 2020-06-11
-last-updated: 2021-02-09
+last-updated: 2024-03-04
 status: implemented
 ---
 
@@ -148,7 +150,7 @@ this](https://docs.google.com/document/d/1-czjvjfpuIqYKsfkvZ5RxIbtoFNLTEtOxaZB71
 3. If an update change the behavior of an already published task, the updated
    task should be a released as a new version.
 
-4. Users of the catalog can reference Tasks in the catalog in their
+4. Users of the catalog can reference StepActions/Tasks in the catalog in their
    TaskRuns and Pipelines including the version they would like to use
 
 5. Users should be able to define their own catalogs as well, and use
@@ -191,7 +193,7 @@ this](https://docs.google.com/document/d/1-czjvjfpuIqYKsfkvZ5RxIbtoFNLTEtOxaZB71
 * Tekton resources : The word "resource" in this doc refers to any
   resource that could be featured in the Tekton Catalog, a.k.a.:
 
-    * Task, Condition, Pipeline, TriggerBinding, TriggerTemplate
+    * Task, Condition, Pipeline, TriggerBinding, TriggerTemplate, StepAction
 
 ### Support Tiers
 
@@ -248,13 +250,13 @@ should guarantee as much *stability* as possible for its user.
   their tasks in an automated way, and [Cool URIs don't
   change](https://www.w3.org/Provider/Style/URI).
 
-* Users may use (and install) a Task automatically, with the
+* Users may use (and install) a StepAction/Task automatically, with the
   assumption that the behavior doesn’t change. If a parameter is
   removed or a behavior changes, it could break the user
-  tasks/pipelines.
+  stepactions/tasks/pipelines.
 
 A version is an identifiable information of a resource along with its
-kind (Task, Pipeline) and name, and it should be present in the
+kind (StepAction, Task, Pipeline) and name, and it should be present in the
 definition of the resource. The location of a resource in the catalog
 should be computable given its Kind, Name and the
 Version. e.g. /{kind}/{name}/{version}/{name}.yaml -
@@ -328,7 +330,7 @@ also provide a folder in tektoncd/experimental for this.
 ### Compatibility
 
 Right now the only indication of what versions of Tekton Pipelines a
-Task works with is the apiVersion, currently with possible values of
+StepAction/Task works with is the apiVersion, currently with possible values of
 v1alpha1 and v1beta1. But additive changes can be made between
 releases.
 
@@ -390,9 +392,23 @@ following organization is proposed.
 ./{resource-type}/{resource-name}/{version}/samples/… |
 ```
 
-For example (with Task and Pipelines):
+For example (with StepActions, Task and Pipelines):
 
 ```
+./stepaction/
+  /argocd
+    /0.1
+      /README.md
+      /argocd.yaml
+      /samples/deploy-to-k8s.yaml
+    /0.2/...
+    /OWNERS
+    /README.md
+  /golang-build
+    /0.1
+      /README.md
+      /golang-build.yaml
+      /samples/golang-build.yaml
 ./task/
   /argocd
     /0.1

--- a/teps/0115-tekton-catalog-git-based-versioning.md
+++ b/teps/0115-tekton-catalog-git-based-versioning.md
@@ -2,13 +2,15 @@
 status: implemented
 title: Tekton Catalog Git-Based Versioning
 creation-date: '2022-07-12'
-last-updated: '2022-12-14'
+last-updated: '2024-03-04'
 authors:
 - "@jerop"
 - "@vdemeester"
 - "@vinamra28"
 - "@QuanZhang-William"
 - "@wlynch"
+contributors:
+- "@chitrangpatel"
 see-also:
 - TEP-0003
 - TEP-0079
@@ -83,9 +85,42 @@ The Catalog organization contract with directory-based versioning is:
 ./{resource-type}/{resource-name}/{version}/samples/...
 ```
 
-For example, the a Tekton Catalog with multiple `Tasks` and `Pipelines` is organized as such:
+For example, the a Tekton Catalog with multiple `StepActions`, `Tasks` and `Pipelines` is organized as such:
 
 ```bash
+./stepaction/
+  /argocd
+    /0.1
+      /README.md
+      /argocd.yaml
+      /samples
+      /tests
+    /0.2
+      /README.md
+      /argocd.yaml
+      /samples
+      /tests
+    /OWNERS
+  /golang-build
+    /0.1
+      /README.md
+      /golang-build.yaml
+      /samples
+      /tests
+    /0.2
+      /README.md
+      /golang-build.yaml
+      /samples
+      /tests
+    /OWNERS
+  /foo-stepaction
+    /0.1
+    /0.2 
+  /bar-stepaction
+    /0.1
+    /0.2
+    /0.3
+  /...
 ./task/
   /argocd
     /0.1
@@ -172,7 +207,7 @@ TEP. A repository may be a Catalog.
 is defined in [TEP-0003: Tekton Catalog Organization][tep-0003-org] and the [git-based contract](#organization-contract)
 is defined in this TEP. A Catalog may contain one or more resources.
 
-* **Resource**: Item shared in a Catalog e.g. `Task` or `Pipeline`.
+* **Resource**: Item shared in a Catalog e.g. `StepAction`, `Task` or `Pipeline`.
 
 * **Hub**: User interface for one or more Catalogs.
     * **Artifact Hub (https://artifacthub.io/)**: The primary and suggested user interface for Tekton Catalogs. Catalogs with git-based versioning will **ONLY** be discussed in the Artifact Hub in the first iteration of this TEP.
@@ -510,7 +545,7 @@ TEP-0115 is `implemented`.
 ##### Getting Started with Git-Based Versioning
 
 To make it easy for the community to create Catalogs, we will provide a template Catalog in the `tektoncd-catalog`
-GitHub organization - https://github.com/tektoncd-catalog. This template will contain `Tasks` and `Pipelines`, and
+GitHub organization - https://github.com/tektoncd-catalog. This template will contain `StepActions`, `Tasks` and `Pipelines`, and
 will include the testing setup that users can use to get started in validating the functionality of their resources.
 Note that we are planning to update the testing setup to be Tekton-based in [TEP-0079][tep-0079]; the updated testing
 set up will be provided in the template Catalog.

--- a/teps/README.md
+++ b/teps/README.md
@@ -8,7 +8,7 @@ This is the complete list of Tekton TEPs:
 |------|--------|----------|---------------|
 |[TEP-0001](0001-tekton-enhancement-proposal-process.md) | Tekton Enhancement Proposal Process | implemented | 2020-06-11 |
 |[TEP-0002](0002-custom-tasks.md) | Custom Tasks | implemented | 2021-12-15 |
-|[TEP-0003](0003-tekton-catalog-organization.md) | Tekton Catalog Organization | implemented | 2021-02-09 |
+|[TEP-0003](0003-tekton-catalog-organization.md) | Tekton Catalog Organization | implemented | 2024-03-04 |
 |[TEP-0004](0004-task-results-in-final-tasks.md) | Task Results in Final Tasks | implemented | 2021-06-03 |
 |[TEP-0005](0005-tekton-oci-bundles.md) | Tekton OCI Bundles | implemented | 2022-01-04 |
 |[TEP-0006](0006-tekton-metrics.md) | Tekton Metrics | proposed | 2020-07-13 |
@@ -105,7 +105,7 @@ This is the complete list of Tekton TEPs:
 |[TEP-0111](0111-propagating-workspaces.md) | Propagating Workspaces | implemented | 2022-09-16 |
 |[TEP-0112](0112-replace-volumes-with-workspaces.md) | Replace Volumes with Workspaces | proposed | 2022-07-20 |
 |[TEP-0114](0114-custom-tasks-beta.md) | Custom Tasks Beta | implemented | 2022-12-12 |
-|[TEP-0115](0115-tekton-catalog-git-based-versioning.md) | Tekton Catalog Git-Based Versioning | implemented | 2022-12-14 |
+|[TEP-0115](0115-tekton-catalog-git-based-versioning.md) | Tekton Catalog Git-Based Versioning | implemented | 2024-03-04 |
 |[TEP-0116](0116-referencing-finally-task-results-in-pipeline-results.md) | Referencing Finally Task Results in Pipeline Results | implemented | 2022-08-11 |
 |[TEP-0117](0117-tekton-results-logs.md) | Tekton Results Logs | implemented | 2023-03-22 |
 |[TEP-0118](0118-matrix-with-explicit-combinations-of-parameters.md) | Matrix with Explicit Combinations of Parameters | implemented | 2022-08-08 |


### PR DESCRIPTION
This PR updates the existing TEPs that lay out the directory-based and git-based verisoning of the Tekton Catalog to also include StepActions.


/kind misc
