### PR TITLE
add jkhelil to the tektoncd org

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -91,6 +91,7 @@ orgs:
     - jisoolee
     - jjasghar
     - jkandasa
+    - jkhelil
     - jkutner
     - jlpettersson
     - jmcshane


### PR DESCRIPTION
@jkhelil is part of the openshift-pipelines teams. Currently he is focusing on operator component.
I would like to add him as member of tektoncd org.