### PR TITLE
Add rhybrillou as a member

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -186,6 +186,7 @@ orgs:
     - ramessesii2
     - shipit
     - siamaksade
+    - rhybrillou
     # alumni:
     # sbwsg
     teams:


### PR DESCRIPTION
Add @rhybrillou as a member in the community as he is a prospective owner in the catalog repo as well as already marked as an expected owner within the catalog repo (see [this PR](https://github.com/tektoncd/catalog/pull/1259)).

He is a colleague working within the same team as me within Red Hat on Advanced Cluster Security.