### PR TITLE
TEP: Mark TEP-0032 as deferred

### DIFF
--- a/teps/0032-tekton-notifications.md
+++ b/teps/0032-tekton-notifications.md
@@ -1,11 +1,17 @@
 ---
-status: proposed
+status: deferred
 title: Tekton Notifications
 creation-date: '2020-11-18'
-last-updated: '2020-11-18'
+last-updated: '2025-02-24'
 authors:
 - '@afrittoli'
 ---
+
+*This TEP is marked as `deferred`, meaning that it is not currently
+being worked on. If you are interested in working on this TEP, please
+reach out to the Tekton Maintainers via the
+[tektoncd-dev](https://groups.google.com/g/tekton-dev) mailing list or
+a GitHub Discussion in the repository.*
 
 # TEP-0032: Tekton Notifications
 

--- a/teps/README.md
+++ b/teps/README.md
@@ -34,7 +34,7 @@ This is the complete list of Tekton TEPs:
 |[TEP-0029](0029-step-workspaces.md) | step-and-sidecar-workspaces | implemented | 2022-07-22 |
 |[TEP-0030](0030-workspace-paths.md) | workspace-paths | proposed | 2020-10-18 |
 |[TEP-0031](0031-tekton-bundles-cli.md) | tekton-bundles-cli | implemented | 2021-03-26 |
-|[TEP-0032](0032-tekton-notifications.md) | Tekton Notifications | proposed | 2020-11-18 |
+|[TEP-0032](0032-tekton-notifications.md) | Tekton Notifications | deferred | 2025-02-24 |
 |[TEP-0033](0033-tekton-feature-gates.md) | Tekton Feature Gates | implemented | 2021-12-16 |
 |[TEP-0035](0035-document-tekton-position-around-policy-authentication-authorization.md) | document-tekton-position-around-policy-authentication-authorization | implementable | 2020-12-09 |
 |[TEP-0036](0036-start-measuring-tekton-pipelines-performance.md) | Start Measuring Tekton Pipelines Performance | proposed | 2020-11-20 |


### PR DESCRIPTION
Added note about TEP-0032 (Tekton Notifications) being deferred and
not actively worked on.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind tep
