### PR TITLE
TEP: Mark TEP-0063 as withdrawn

### DIFF
--- a/teps/0063-workspace-dependencies.md
+++ b/teps/0063-workspace-dependencies.md
@@ -1,11 +1,14 @@
 ---
-status: proposed
+status: withdrawn
 title: Workspace Dependencies
 creation-date: '2021-04-23'
-last-updated: '2021-04-23'
+last-updated: '2025-02-24'
 authors:
 - '@jerop'
 ---
+
+*This TEP is marked as `withdrawn` as it doesn't really had too much on
+top of using `runAfter` and workspaces.*
 
 # TEP-0063: Workspace Dependencies
 

--- a/teps/README.md
+++ b/teps/README.md
@@ -61,7 +61,7 @@ This is the complete list of Tekton TEPs:
 |[TEP-0060](0060-remote-resource-resolution.md) | Remote Resource Resolution | implemented | 2022-10-24 |
 |[TEP-0061](0061-allow-custom-task-to-be-embedded-in-pipeline.md) | Allow custom task to be embedded in pipeline | implemented | 2021-05-26 |
 |[TEP-0062](0062-catalog-tags-and-hub-categories-management.md) | Catalog Tags and Hub Categories Management | implemented | 2021-12-15 |
-|[TEP-0063](0063-workspace-dependencies.md) | Workspace Dependencies | proposed | 2021-04-23 |
+|[TEP-0063](0063-workspace-dependencies.md) | Workspace Dependencies | withdrawn | 2025-02-24 |
 |[TEP-0066](0066-dogfooding-tekton.md) | Dogfooding Tekton | proposed | 2021-05-16 |
 |[TEP-0067](0067-tekton-catalog-pipeline-organization.md) | Tekton Catalog Pipeline Organization | implemented | 2023-03-21 |
 |[TEP-0069](0069-support-retries-for-custom-task-in-a-pipeline.md) | Support retries for custom task in a pipeline. | implemented | 2021-12-15 |


### PR DESCRIPTION
Added note about TEP-0043 (Workspace Dependencies) being withdrawn.

*This TEP is marked as `withdrawn` as it doesn't really had too much on
top of using `runAfter` and workspaces.*

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind tep
