### PR TITLE
TEP: Mark TEP-0044 as withdrawn

### DIFF
--- a/teps/0044-data-locality-and-pod-overhead-in-pipelines.md
+++ b/teps/0044-data-locality-and-pod-overhead-in-pipelines.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: withdrawn
 title: Data Locality and Pod Overhead in Pipelines
 creation-date: '2021-01-22'
 last-updated: '2025-02-24'

--- a/teps/README.md
+++ b/teps/README.md
@@ -44,7 +44,7 @@ This is the complete list of Tekton TEPs:
 |[TEP-0040](0040-ignore-step-errors.md) | Ignore Step Errors | implemented | 2021-08-11 |
 |[TEP-0041](0041-tekton-component-versioning.md) | Tekton Component Versioning | implemented | 2023-03-21 |
 |[TEP-0042](0042-taskrun-breakpoint-on-failure.md) | taskrun-breakpoint-on-failure | implemented | 2021-12-10 |
-|[TEP-0044](0044-data-locality-and-pod-overhead-in-pipelines.md) | Data Locality and Pod Overhead in Pipelines | proposed | 2025-02-24 |
+|[TEP-0044](0044-data-locality-and-pod-overhead-in-pipelines.md) | Data Locality and Pod Overhead in Pipelines | withdrawn | 2025-02-24 |
 |[TEP-0045](0045-whenexpressions-in-finally-tasks.md) | WhenExpressions in Finally Tasks | implemented | 2021-06-03 |
 |[TEP-0046](0046-finallytask-execution-post-timeout.md) | Finally tasks execution post pipelinerun timeout | implemented | 2021-12-14 |
 |[TEP-0047](0047-pipeline-task-display-name.md) | Pipeline Task Display Name | implemented | 2023-03-30 |


### PR DESCRIPTION
Follow-up to https://github.com/tektoncd/community/pull/1182

A note was added in a previous change to mark TEP-0044 as withdrawn but the status field was not updated.