### PR TITLE
Add pramodbindal as org member

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -132,6 +132,7 @@ orgs:
     - piyush-garg
     - popcor255
     - pradeepitm12
+    - pramodbindal
     - pratap0007
     - praveen4g0
     - pritidesai


### PR DESCRIPTION
Request to become Org Member.

@pramodbindal  is part of tekton team at RedHat and endorced by @vdemeester 


