### PR TITLE
Add waveywaves to core.maintainers group

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -277,6 +277,7 @@ orgs:
         - yongxuanzhang
         - chitrangpatel
         - JeromeJu
+        - waveywaves
         privacy: closed
         repos:
           pipeline: maintain


### PR DESCRIPTION
This is to reflect OWNERS file from tektoncd/pipeline.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
