### PR TITLE
Add @aThorp96 to org

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -22,6 +22,7 @@ orgs:
     - adambkaplan
     - ak1394
     - anithapriyanatarajan
+    - aThorp96
     - avinal
     - Basavaraju-G
     - dhaus67


### PR DESCRIPTION
Request to add @athorp (me) as a Tekton org member

@aThorp96 is a member of the Tekton team at Red Hat and is endorsed by @vdemeester.