### PR TITLE
Add @brianwcook to org

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -197,6 +197,7 @@ orgs:
     - cugykw
     - l-qing
     - twoGiants
+    - brianwcook
     # alumni:
     # sbwsg
     teams:


### PR DESCRIPTION
@brianwcook is a member of the Konflux team at Red Hat working also on tekton and is endorsed by @vdemeester.