### PR TITLE
Update OWNERS according to goverance board

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,8 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- jerop
+- dibyom
 - vdemeester
 - afrittoli
-- chitrangpatel
+- abayer
 - wlynch


### PR DESCRIPTION
Something we didn't update after the election is the OWNERS of the
repository. The should map goverance member, which was not the case.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
