### PR TITLE
Add mangelajo and bkhizgiy to the tektoncd org

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -197,6 +197,8 @@ orgs:
     - l-qing
     - twoGiants
     - brianwcook
+    - bkhizgiy
+    - mangelajo
     # alumni:
     # sbwsg
     teams:


### PR DESCRIPTION
mangelajo and I (bkhizgiy) are part of RHIVOS and are working on the Jumpstarter project. We're going to own these tasks in the tektoncd/catalog (see https://github.com/tektoncd/catalog/pull/1340).

We'd like to become part of the org to maintain our tasks. Thanks!