### PR TITLE
feat: includes pruner members and collaborators

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -366,6 +366,19 @@ orgs:
         repos:
           plumbing: maintain
           infra: maintain
+      pruner.maintainers:
+        description: the pruner maintainers
+        maintainers:
+        - vdemeester
+        members:
+        - anithapriyanatarajan
+        - infernus01
+        - pramodbindal
+        - savitaashture
+        - waveywaves
+        privacy: closed
+        repos:
+          pruner: maintain
       results.maintainers:
         description: the results maintainers
         maintainers:
@@ -685,6 +698,20 @@ orgs:
         repos:
           plumbing: read
           infra: read
+      pruner.collaborators:
+        description: the pruner collaborators
+        maintainers:
+        - vdemeester
+        members:
+        - anithapriyanatarajan
+        - infernus01
+        - jkandasa
+        - pramodbindal
+        - savitaashture
+        - waveywaves
+        privacy: closed
+        repos:
+          pruner: read
       cli.collaborators:
         description: The cli collaborators
         maintainers:


### PR DESCRIPTION
This pull request updates the organization configuration in `org/org.yaml` to add new teams for the `pruner` repository. 

**Pruner team additions:**

* Added a new `pruner.maintainers` team granting `maintain` access to the `tektoncd/pruner` repository.
* Added a new `pruner.collaborators` team  granting `read` access to the `tektoncd/pruner` repository.