### PR TITLE
Add dorzel to tektoncd members

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -204,6 +204,7 @@ orgs:
     - zakisk
     - gbenhaim
     - mathur07
+    - dorzel
     # alumni:
     # sbwsg
     teams:


### PR DESCRIPTION
Related to https://github.com/tektoncd/catalog/pull/1351, adding dorzel to tektoncd members. 

@afrittoli @vdemeester 