### PR TITLE
add anithapriyanatarajan to chains maintainers team

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -249,6 +249,7 @@ orgs:
       chains.maintainers:
         description: the chains maintainers
         members:
+        - anithapriyanatarajan
         - chitrangpatel
         - chuangw6
         - jkhelil
@@ -894,12 +895,14 @@ orgs:
       chains.collaborators:
         description: The chains collaborators
         members:
+        - anithapriyanatarajan
         - abayer
         - afrittoli
         - chuangw6
         - chitrangpatel
         - dlorenc
         - ImJasonH
+        - jkhelil
         - lcarva
         - mattmoor
         - pritidesai


### PR DESCRIPTION
Anitha has contributed several commits to the project and actively monitors bug fixes. Her involvement in both development and quality assurance demonstrates her understanding of the project’s codebase and maintenance needs, making her a strong candidate for a maintainers role.