### PR TITLE
Add 'pramodbindal' as maintainer of operator repo

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -350,6 +350,7 @@ orgs:
         - jkhelil
         - anithapriyanatarajan
         - mbpavan
+        - pramodbindal
         privacy: closed
         repos:
           operator: maintain


### PR DESCRIPTION
I have contributed to operator  for multiple instances which include onboarding  TektonPruner and TektonCaches.
Apart from this I have reviewed PRs and added my comments whenever  needed.

Adding me as maintainer in operator repo will enable me to approve the PRs i review.