### PR TITLE
Add Shubham Bharadwaj as maintainer for Pruner repository

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -391,6 +391,7 @@ orgs:
         - pramodbindal
         - savitaashture
         - waveywaves
+        - infernus01
         privacy: closed
         repos:
           pruner: maintain


### PR DESCRIPTION
Shubham Bharadwaj (@infernus01) has made significant contribution to the pruner project and is aware of the overall architecture and release steps. Would like to nominate him as maintainer for Pruner. Please approve.

cc: @vdemeester @afrittoli @AlanGreene @waveywaves @savitaashture 