### PR TITLE
Add anithapriyanatarajan to community.collaborators

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -603,6 +603,7 @@ orgs:
         - vincent-pli
         - mpeters
         - afrittoli
+        - anithapriyanatarajan
         - vinamra28
         - pierretasci
         - priyawadhwa


### PR DESCRIPTION
## Summary

- Adds `anithapriyanatarajan` to the `community.collaborators` team in org.yaml

This gives Anitha read access to the community repository for reviews. She is already a member of the Tekton organization and is a maintainer/collaborator on several other teams (chains, operator, pruner, mcp-server).

/kind misc