### PR TITLE
TEP-0164: Tekton Artifacts Phase 2 — External Storage for Artifacts and Results

### DIFF
--- a/teps/0164-larger-results-via-external-storage.md
+++ b/teps/0164-larger-results-via-external-storage.md
@@ -1,0 +1,909 @@
+---
+title: Larger Results via External Storage with Pluggable Backends
+authors:
+  - "@vdemeester"
+creation-date: 2026-02-04
+last-updated: 2026-02-09
+status: proposed
+see-also:
+  - TEP-0085
+  - TEP-0086
+  - TEP-0127
+---
+
+# TEP-0164: Larger Results via External Storage with Pluggable Backends
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+  - [Use Cases](#use-cases)
+  - [Requirements](#requirements)
+- [Proposal](#proposal)
+  - [Notes and Caveats](#notes-and-caveats)
+- [Design Details](#design-details)
+  - [New Result Type: external](#new-result-type-external)
+  - [Behavior When External Storage Is Not Configured](#behavior-when-external-storage-is-not-configured)
+  - [Storage Backend Configuration](#storage-backend-configuration)
+  - [Namespace-Level Configuration](#namespace-level-configuration)
+  - [TaskRun Status with References](#taskrun-status-with-references)
+  - [Transparent Resolution for Downstream Tasks](#transparent-resolution-for-downstream-tasks)
+  - [Init Container Injection for Large Results](#init-container-injection-for-large-results)
+  - [Pipeline-Level Result Declarations](#pipeline-level-result-declarations)
+  - [Integration with External Tools and Services](#integration-with-external-tools-and-services)
+  - [Storage Provider Interface](#storage-provider-interface)
+  - [Supported Backends](#supported-backends)
+  - [Garbage Collection](#garbage-collection)
+- [Design Evaluation](#design-evaluation)
+  - [Reusability](#reusability)
+  - [Simplicity](#simplicity)
+  - [Flexibility](#flexibility)
+  - [Conformance](#conformance)
+  - [User Experience](#user-experience)
+  - [Performance](#performance)
+  - [Risks and Mitigations](#risks-and-mitigations)
+  - [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+  - [TEP-0127: Sidecar Logs](#tep-0127-sidecar-logs)
+  - [ConfigMaps per TaskRun](#configmaps-per-taskrun)
+  - [Custom CRD for Results](#custom-crd-for-results)
+  - [Workspaces Only](#workspaces-only)
+- [Implementation Plan](#implementation-plan)
+  - [Test Plan](#test-plan)
+  - [Infrastructure Needed](#infrastructure-needed)
+  - [Upgrade and Migration Strategy](#upgrade-and-migration-strategy)
+  - [Implementation Pull Requests](#implementation-pull-requests)
+- [References](#references)
+<!-- /toc -->
+
+## Summary
+
+This TEP proposes a new approach to handling large Task results by introducing
+external storage backends with pluggable providers. Instead of storing large
+result values directly in the TaskRun status (limited by Kubernetes CRD size
+constraints), this proposal allows results to be stored in external storage
+systems (S3, GCS, OCI registries, etc.) while only storing a reference in
+the TaskRun status.
+
+This approach provides:
+- **No per-pod overhead**: Unlike TEP-0127's sidecar approach, no additional
+  containers are injected into TaskRun pods
+- **Truly unlimited result sizes**: Limited only by the external storage backend
+- **Per-result opt-in**: Only results marked as `type: external` use external
+  storage; existing behavior remains unchanged for inline results
+- **Pluggable backends**: Operators can configure their preferred storage
+  backend (S3, GCS, OCI registry, Azure Blob, PVC)
+- **Transparent resolution**: Downstream tasks can reference external results
+  using the same syntax as inline results
+
+## Motivation
+
+Tekton Results are currently severely constrained by Kubernetes limitations:
+
+1. **Termination Message Limit**: Results are stored via container termination
+   messages, limited to 4KB per container and 12KB total per Pod across all
+   containers.
+
+2. **Container Count Impact**: The more Steps in a Task, the smaller
+   each result can be. For example, with 12 containers in a pod, each
+   container gets only ~1KB for its termination message.
+
+3. **CRD Size Limit**: Even with TEP-0127's sidecar logs approach, results
+   ultimately end up in the TaskRun status, subject to the ~1.5MB CRD size
+   limit.
+
+These limitations significantly impact real-world use cases:
+
+- **Tekton Chains**: Signing multiple container images produces large lists
+  of digest-pinned image references that exceed result limits
+- **SBOM Generation**: Software Bill of Materials documents are typically
+  10KB-10MB in size
+- **Build Manifests**: Multi-architecture build manifests listing all produced
+  artifacts
+- **JSON API Responses**: Tasks that fetch or transform JSON data between steps
+
+### Goals
+
+1. Enable Tasks to produce results of arbitrary size without impacting TaskRun
+   pod overhead
+2. Provide a pluggable storage backend system that operators can configure
+3. Maintain backward compatibility with existing inline results
+4. Allow per-result opt-in to external storage
+5. Ensure transparent resolution so downstream tasks can consume external
+   results without special handling
+6. Support integrity verification via content digests
+
+### Non-Goals
+
+1. Replacing Tekton Results project - this TEP focuses on inter-task result
+   passing, not long-term storage and querying
+2. Automatic result streaming or real-time result access during Task execution
+3. Providing a general-purpose artifact storage system (use Workspaces for that)
+4. Solving the termination message limit for inline results (that remains at 4KB)
+
+### Use Cases
+
+**Use Case 1: Multi-Image Build Pipeline (Konflux)**
+
+A Task builds multiple container images and needs to pass the list of all
+image references (with digests) to a signing Task. With 20+ images, the
+result easily exceeds 4KB.
+
+```yaml
+# build-images Task
+results:
+  - name: IMAGES
+    type: external
+    description: JSON array of built image references with digests
+
+# sign-images Task
+params:
+  - name: images
+    value: $(tasks.build-images.results.IMAGES)
+```
+
+**Use Case 2: SBOM Generation**
+
+A Task generates an SBOM in SPDX or CycloneDX format that needs to be
+passed to an attestation Task.
+
+```yaml
+results:
+  - name: sbom
+    type: external
+    description: SPDX SBOM document
+```
+
+**Use Case 3: Test Results Processing**
+
+A test Task produces detailed JUnit XML output that needs to be processed
+by a reporting Task.
+
+```yaml
+results:
+  - name: junit-report
+    type: external
+    description: JUnit XML test results
+```
+
+### Requirements
+
+**Must Have:**
+
+1. **Backward Compatibility**: Existing Tasks and Pipelines must continue to
+   work without modification
+2. **Opt-in**: External storage must be explicitly requested per-result
+3. **Configurable**: Operators must be able to configure storage backends
+   at the cluster level
+4. **Secure**: Credentials for storage backends must be handled securely
+5. **Verifiable**: Result integrity must be verifiable via content digests
+6. **Clear failure modes**: When external storage is not configured but
+   `type: external` is used, the failure must be immediate and obvious
+
+**Nice to Have (can be deferred):**
+
+7. **Garbage Collection**: External results should be cleanable when TaskRuns
+   are deleted. For MVP, operators can rely on storage lifecycle policies.
+8. **Namespace-level configuration**: Per-namespace storage backend overrides
+
+## Proposal
+
+Introduce a new result type `external` that stores result content in a
+configured external storage backend and stores only a reference (with digest)
+in the TaskRun status.
+
+The key components are:
+
+1. **New Result Type**: `type: external` in Task spec
+2. **Storage Backend Configuration**: Cluster-level ConfigMap for default
+   backend, with optional namespace-level overrides
+3. **Reference Storage**: TaskRun status stores a reference object instead
+   of the full value
+4. **Transparent Resolution**: The entrypoint binary and controller handle
+   fetching external results when needed by downstream tasks
+5. **Pluggable Provider Interface**: Go interface that storage providers
+   implement
+
+### Notes and Caveats
+
+- External storage requires additional infrastructure (S3 bucket, GCS bucket,
+  or OCI registry)
+- Network latency for fetching external results may impact Pipeline execution
+  time
+- Storage credentials must be available to:
+  - TaskRun pods (for uploading results via entrypoint)
+  - Tekton Pipelines controller (for resolving results in downstream tasks)
+  - External tools/services that consume results (e.g., Tekton Chains for
+    attestation, Tekton Results for long-term storage)
+- Tasks declaring `type: external` results will fail validation on clusters
+  without external storage configured
+
+## Design Details
+
+### New Result Type: external
+
+Tasks can declare results with `type: external`:
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: build-images
+spec:
+  results:
+    - name: digest
+      type: string           # inline, current behavior (default)
+      description: Primary image digest
+    - name: IMAGES
+      type: external         # NEW: stored externally
+      description: JSON array of all built images with digests
+    - name: sbom
+      type: external
+      description: SPDX SBOM document
+      properties:
+        maxSize: 10Mi        # optional: hint for storage allocation
+  steps:
+    - name: build
+      image: builder:latest
+      script: |
+        # Small result - written to inline result path
+        echo -n "sha256:abc123..." > $(results.digest.path)
+
+        # Large results - written to external result path (same API)
+        cat images.json > $(results.IMAGES.path)
+        cat sbom.spdx.json > $(results.sbom.path)
+```
+
+The Task author experience is identical - results are written to the same
+paths. The difference is in how the entrypoint handles them.
+
+### Behavior When External Storage Is Not Configured
+
+A key design question is: what happens when a Task declares `type: external`
+for a result, but the cluster has no external storage backend configured?
+
+**Proposed behavior:**
+
+1. **Validation at admission time**: When a Task or TaskRun with `type: external`
+   results is submitted and the feature flag `enable-external-results` is not
+   enabled or no backend is configured, the controller should reject the
+   resource with a clear error message:
+
+   ```
+   Error: Task "build-images" declares external result "IMAGES" but external
+   result storage is not configured. Either configure a storage backend in
+   config-result-storage ConfigMap or change the result type to "string".
+   ```
+
+2. **Feature flag gating**: The `type: external` result type is only valid when
+   the `enable-external-results` feature flag is set to `"true"`. This ensures
+   Tasks using external results are only accepted on clusters that support them.
+
+3. **Graceful degradation option** (future consideration): An optional
+   `fallback-to-inline: "true"` configuration could allow external results to
+   fall back to inline storage if the content is small enough. This would be
+   useful during migration periods.
+
+This approach ensures that:
+- Tasks are portable: they clearly declare their requirements
+- Failures are fast and obvious: no silent data loss or truncation
+- Operators have clear guidance on what configuration is needed
+
+### Storage Backend Configuration
+
+Cluster-level default configuration via ConfigMap:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-result-storage
+  namespace: tekton-pipelines
+data:
+  # Enable external result storage (default: "false")
+  enabled: "true"
+
+  # Default backend type: s3, gcs, oci, azure, pvc
+  backend: "s3"
+
+  # S3 configuration
+  s3.bucket: "tekton-results"
+  s3.region: "us-east-1"
+  s3.endpoint: ""                    # optional, for MinIO/other S3-compatible
+  s3.pathStyle: "false"              # set to "true" for MinIO
+  s3.credentialsSecret: "tekton-results-s3-creds"
+
+  # Key pattern for storing results
+  # Available variables: {{namespace}}, {{taskrun}}, {{result}}
+  keyPattern: "{{namespace}}/{{taskrun}}/{{result}}"
+```
+
+Alternative backend configurations:
+
+```yaml
+# GCS configuration
+data:
+  backend: "gcs"
+  gcs.bucket: "tekton-results"
+  gcs.credentialsSecret: "tekton-results-gcs-creds"
+  gcs.credentialsKey: "service-account.json"
+
+# OCI Registry configuration
+data:
+  backend: "oci"
+  oci.registry: "registry.example.com"
+  oci.repository: "tekton/results"
+  oci.credentialsSecret: "tekton-results-oci-creds"
+
+# Azure Blob configuration
+data:
+  backend: "azure"
+  azure.container: "tekton-results"
+  azure.accountName: "tektonresults"
+  azure.credentialsSecret: "tekton-results-azure-creds"
+```
+
+### Namespace-Level Configuration
+
+In addition to cluster-level defaults, operators may want to configure
+different storage backends per namespace. This is particularly useful in
+multi-tenant environments where different teams have different storage
+requirements or credentials.
+
+Namespace-level configuration follows the patterns established in
+[TEP-0085: Per-Namespace Controller Configuration](https://github.com/tektoncd/community/blob/main/teps/0085-per-namespace-controller-configuration.md).
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-result-storage
+  namespace: team-a  # Namespace-specific override
+  labels:
+    tekton.dev/config-type: result-storage
+data:
+  backend: "oci"
+  oci.registry: "team-a-registry.example.com"
+  oci.repository: "tekton/results"
+  oci.credentialsSecret: "team-a-registry-creds"
+```
+
+The controller resolves configuration in the following order:
+1. Namespace-level ConfigMap (if exists)
+2. Cluster-level ConfigMap in `tekton-pipelines` namespace
+3. Built-in defaults (external results disabled)
+
+### TaskRun Status with References
+
+When a TaskRun completes with external results, the status contains references:
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: build-images-run-abc123
+spec:
+  taskRef:
+    name: build-images
+status:
+  conditions:
+    - type: Succeeded
+      status: "True"
+  results:
+    # Inline result - stored directly
+    - name: digest
+      type: string
+      value: "sha256:abc123def456..."
+
+    # External result - reference only
+    - name: IMAGES
+      type: external
+      ref:
+        backend: s3
+        bucket: tekton-results
+        key: "default/build-images-run-abc123/IMAGES"
+        digest: "sha256:789xyz..."
+        size: 45678
+        contentType: "application/json"
+
+    # Another external result
+    - name: sbom
+      type: external
+      ref:
+        backend: s3
+        bucket: tekton-results
+        key: "default/build-images-run-abc123/sbom"
+        digest: "sha256:def789..."
+        size: 2457600
+        contentType: "application/spdx+json"
+```
+
+### Transparent Resolution for Downstream Tasks
+
+Downstream tasks reference external results using the standard syntax:
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: build-sign-attest
+spec:
+  tasks:
+    - name: build
+      taskRef:
+        name: build-images
+
+    - name: sign
+      taskRef:
+        name: sign-images
+      params:
+        - name: images
+          # Same syntax - controller resolves external reference
+          value: $(tasks.build.results.IMAGES)
+      runAfter:
+        - build
+
+    - name: attest
+      taskRef:
+        name: create-attestation
+      params:
+        - name: sbom
+          value: $(tasks.build.results.sbom)
+      runAfter:
+        - build
+```
+
+The PipelineRun controller:
+
+1. Detects that `$(tasks.build.results.IMAGES)` references an external result
+2. Injects an init container to fetch the content from storage
+3. Substitutes the result reference with the file path where content is available
+
+### Init Container Injection for External Results
+
+All external results use an init container approach for downstream resolution.
+This provides a consistent, simple model: `type: external` results are always
+file-based, while `type: string` results remain inline.
+
+**How it works:**
+
+1. **Init container injection**: The controller injects an init container into
+   downstream TaskRun pods that:
+   - Fetches the external result content from storage
+   - Writes it to a shared emptyDir volume at a well-known path
+   - Verifies the content digest matches the reference
+
+2. **File path substitution**: The controller substitutes result references
+   with file paths:
+
+   ```yaml
+   # Original parameter reference
+   value: $(tasks.build.results.sbom)
+
+   # Becomes
+   value: /tekton/results/external/build/sbom
+   ```
+
+3. **Well-known path structure**: External results are available at:
+   ```
+   /tekton/results/external/<task-name>/<result-name>
+   ```
+
+**Why always use init containers (no size threshold):**
+
+- **Simplicity**: One code path instead of branching based on size
+- **Consistency**: All external results behave the same way
+- **No tuning**: No threshold to configure or optimize
+- **Clear mental model**: `type: external` = file-based, `type: string` = inline
+- **Future-proof**: Results can grow without changing behavior
+
+If a result is small enough to be inline, it should use `type: string`.
+Declaring `type: external` is an explicit signal that file-based handling
+is appropriate.
+
+### Pipeline-Level Result Declarations
+
+Pipelines can declare results that reference Task results. When a Task result
+is declared as `type: external`, the Pipeline result can also be declared as
+external:
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: build-and-sign
+spec:
+  results:
+    - name: images
+      type: external  # Pipeline result is also external
+      value: $(tasks.build.results.IMAGES)
+    - name: digest
+      type: string    # Inline result from task
+      value: $(tasks.build.results.digest)
+  tasks:
+    - name: build
+      taskRef:
+        name: build-images
+```
+
+**Behavior:**
+
+- When a Pipeline result references an external Task result with
+  `type: external`, the PipelineRun status stores the same reference
+  (no re-upload needed).
+
+- When a Pipeline result references an external Task result with
+  `type: string` (inline), the controller fetches the external content
+  and stores it inline in the PipelineRun status (subject to size limits).
+
+- Attempting to declare a Pipeline result as `type: string` when referencing
+  a very large external Task result will fail with a clear error message.
+
+### Integration with External Tools and Services
+
+External results must be accessible not only to the Tekton controller but
+also to other tools and services in the Tekton ecosystem that consume
+TaskRun results.
+
+**Tekton Chains Integration:**
+
+[Tekton Chains](https://github.com/tektoncd/chains) monitors TaskRun
+completions and creates attestations based on results. For external results:
+
+1. Chains must have access to the same storage credentials as the controller
+2. Chains uses the `ResultRef` to fetch content for attestation
+3. The digest in the reference can be included in the attestation without
+   fetching the full content (for provenance)
+
+**Credential Sharing:**
+
+Storage credentials must be available to:
+- TaskRun pods (for uploading results via entrypoint)
+- Tekton Pipelines controller (for resolving results in downstream tasks)
+- Tekton Chains controller (for creating attestations)
+- Tekton Results (for long-term storage and querying)
+- Any other tools that need to access result content
+
+The recommended approach is to use a shared Secret that all components
+can access, or workload identity (IRSA, GKE Workload Identity) where
+credentials are derived from ServiceAccount annotations.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tekton-results-storage-creds
+  namespace: tekton-pipelines
+  annotations:
+    # Used by controller, chains, and entrypoint
+    tekton.dev/credential-scope: "result-storage"
+type: Opaque
+data:
+  # Credentials shared across components
+  access-key: ...
+  secret-key: ...
+```
+
+### Storage Provider Interface
+
+```go
+package resultstorage
+
+import (
+    "context"
+    "io"
+)
+
+// ResultRef contains the reference to an externally stored result
+type ResultRef struct {
+    Backend     string `json:"backend"`
+    Bucket      string `json:"bucket,omitempty"`
+    Key         string `json:"key"`
+    Digest      string `json:"digest"`
+    Size        int64  `json:"size"`
+    ContentType string `json:"contentType,omitempty"`
+}
+
+// Provider defines the interface for result storage backends
+type Provider interface {
+    // Name returns the provider identifier (s3, gcs, oci, azure, pvc)
+    Name() string
+
+    // Store writes result content and returns a reference
+    Store(ctx context.Context, key string, content io.Reader, opts StoreOptions) (*ResultRef, error)
+
+    // Fetch retrieves result content by reference
+    Fetch(ctx context.Context, ref *ResultRef) (io.ReadCloser, error)
+
+    // Delete removes stored result (for garbage collection)
+    Delete(ctx context.Context, ref *ResultRef) error
+
+    // Exists checks if a result exists
+    Exists(ctx context.Context, ref *ResultRef) (bool, error)
+}
+
+// StoreOptions contains options for storing a result
+type StoreOptions struct {
+    ContentType string
+    Metadata    map[string]string
+}
+
+// ProviderConfig contains configuration for initializing a provider
+type ProviderConfig struct {
+    Backend     string
+    Credentials CredentialsSource
+    Options     map[string]string
+}
+
+// CredentialsSource defines where to get storage credentials
+type CredentialsSource struct {
+    SecretRef *SecretKeySelector
+    // Future: ServiceAccount for workload identity
+}
+```
+
+### Supported Backends
+
+**Phase 1 (MVP):**
+- S3 (via `gocloud.dev/blob/s3blob`)
+- OCI Registry (via `oras.land/oras-go/v2`)
+- PVC (local storage, no external infrastructure needed)
+
+**Phase 2:**
+- GCS (via `gocloud.dev/blob/gcsblob`)
+- Azure Blob (via `gocloud.dev/blob/azureblob`)
+
+**Phase 3:**
+- Custom (webhook-based for extensibility)
+
+### Garbage Collection
+
+External results consume storage that should be cleaned up when no longer
+needed. This section describes the garbage collection strategy.
+
+**Note:** Garbage collection is considered a **nice-to-have for initial
+implementation**. The MVP can rely on external storage lifecycle policies
+(e.g., S3 bucket lifecycle rules) or manual cleanup. Automated garbage
+collection can be added in a later phase.
+
+**Proposed approaches (for future implementation):**
+
+1. **Finalizer-based cleanup**: Add a finalizer to TaskRuns with external
+   results. When the TaskRun is deleted, the controller deletes the
+   associated external result objects before removing the finalizer.
+
+   ```yaml
+   metadata:
+     finalizers:
+       - results.tekton.dev/external-cleanup
+   ```
+
+2. **Background garbage collector**: A separate controller or CronJob that:
+   - Lists all external result references in storage
+   - Checks if the corresponding TaskRun still exists
+   - Deletes orphaned results after a grace period
+
+3. **TTL-based expiration**: Configure storage backend with automatic
+   expiration (e.g., S3 lifecycle policies, OCI tag expiration). Results
+   are automatically deleted after a configurable period.
+
+4. **Integration with Tekton Results**: When Tekton Results is deployed,
+   external result references can be migrated to Results storage before
+   TaskRun deletion, preserving data for historical queries.
+
+**Recommendation for MVP:** Document that operators should configure
+storage lifecycle policies for automatic cleanup, and implement
+finalizer-based cleanup in Phase 2 or 3.
+
+## Design Evaluation
+
+### Reusability
+
+This proposal builds on existing patterns:
+- URI scheme pattern from [tekton-caches](https://github.com/openshift-pipelines/tekton-caches)
+- Storage abstraction from [go-cloud/blob](https://github.com/google/go-cloud)
+- Artifact pattern from [Argo Workflows](https://argo-workflows.readthedocs.io/en/latest/walk-through/artifacts/)
+
+The storage provider interface can be reused by other Tekton components
+(e.g., Tekton Results project, Tekton Chains).
+
+### Simplicity
+
+**Current Experience (without feature):**
+- Users hit 4KB/12KB limits unexpectedly
+- Workarounds: use Workspaces (requires PVC), split results, compress data
+- Sidecar logs approach adds overhead to every TaskRun
+
+**With Feature:**
+- Declare `type: external` on results that may be large
+- Configure storage backend once at cluster level
+- Same result writing API (`echo > $(results.name.path)`)
+- Same result reference syntax (`$(tasks.x.results.y)`)
+
+### Flexibility
+
+- Pluggable backends allow operators to use existing infrastructure
+- OCI registry backend works in environments with only registry access
+- PVC backend (Phase 3) requires no external infrastructure
+- Per-result opt-in means users control which results use external storage
+
+### Conformance
+
+- Extends existing Results API with new type
+- Does not require understanding Kubernetes internals
+- API changes are additive and backward compatible
+- Results syntax remains consistent
+
+### User Experience
+
+**Task Authors:**
+- Add `type: external` to large result declarations
+- Same file-based result writing API
+
+**Pipeline Authors:**
+- No changes - same `$(tasks.x.results.y)` syntax
+
+**Operators:**
+- Configure `config-result-storage` ConfigMap once
+- Manage storage backend credentials
+
+### Performance
+
+**Positive Impact:**
+- No sidecar container overhead on every TaskRun
+- Large results don't bloat etcd/API server
+
+**Potential Impact:**
+- Network latency when fetching external results for downstream tasks
+- Storage backend availability affects Pipeline reliability
+
+**Mitigations:**
+- Content-addressable references enable caching
+- Parallel fetching for multiple external results in a single init container
+- Init container startup overhead is minimal compared to result fetch time
+
+### Risks and Mitigations
+
+| Risk                                    | Mitigation                                                         |
+|-----------------------------------------|--------------------------------------------------------------------|
+| Storage backend unavailable             | Graceful degradation with clear error messages; retry with backoff |
+| Credential management complexity        | Support workload identity (IRSA, GKE WI); clear documentation      |
+| Orphaned results after TaskRun deletion | Garbage collection via finalizers or async cleanup job             |
+| Large result fetching latency           | Caching layer; parallel fetch; optional streaming                  |
+
+### Drawbacks
+
+1. **External Infrastructure Required**: Unlike sidecar logs, this requires
+   additional infrastructure (S3 bucket, registry, etc.)
+
+2. **Credential Management**: Storage credentials must be configured and
+   maintained
+
+3. **Network Dependency**: Result resolution depends on network access to
+   storage backend
+
+4. **Debugging Complexity**: Results are not directly visible in TaskRun status
+
+## Alternatives
+
+### TEP-0127: Sidecar Logs
+
+**Approach**: Inject a sidecar container that monitors result files and emits
+them via stdout; controller reads from pod logs.
+
+**Why Not Chosen**:
+- Creates sidecar on EVERY TaskRun (resource overhead)
+- ~3 second startup time increase per TaskRun
+- Cluster-wide only, no per-Task opt-in
+- Results still end up in TaskRun status (~1.5MB CRD limit)
+- Controller needs pod logs access (security concern)
+- [Issue #8448](https://github.com/tektoncd/pipeline/issues/8448) requests selective enablement
+
+### ConfigMaps per TaskRun
+
+**Approach**: Create a ConfigMap for each TaskRun to store results, then
+copy to TaskRun status.
+
+**Why Not Chosen**:
+- RBAC complexity (controller needs permission to create roles/bindings)
+- Still limited to ~1.5MB per ConfigMap
+- API server load (3+ requests per TaskRun)
+- Cleanup complexity
+
+### Custom CRD for Results
+
+**Approach**: Store results in dedicated TaskRunResult CRD.
+
+**Why Not Chosen**:
+- Still subject to ~1.5MB CRD limit
+- Introduces new resource type to manage
+- Additional API server load
+
+### Workspaces Only
+
+**Approach**: Document that large data should use Workspaces, no changes needed.
+
+**Why Not Chosen**:
+- Requires separate storage infrastructure
+- Changes how users think about results vs files
+- Requires Task modifications to read from workspace paths
+- Breaks task library patterns
+- Incompatible with no-code/low-code abstractions
+
+## Implementation Plan
+
+### Phase 1: Core Infrastructure (Alpha)
+
+1. Define `ResultRef` types in API
+2. Implement `Provider` interface
+3. Implement S3 provider using `gocloud.dev/blob`
+4. Implement OCI provider using ORAS
+5. Add `config-result-storage` ConfigMap handling
+6. Modify entrypoint to upload external results
+7. Feature flag: `enable-external-results: "true"`
+8. Modify TaskRun reconciler to handle external result references
+9. Init container injection for downstream result resolution
+10. Implement result resolution for PipelineRun
+11. Validation: reject `type: external` when storage not configured
+12. E2E tests with S3 and OCI backends
+13. Document storage lifecycle policies for cleanup (defer automated GC)
+
+### Phase 2: Additional Backends and Features (Beta)
+
+1. Implement GCS provider
+2. Implement Azure Blob provider
+3. Implement PVC provider
+4. Namespace-level configuration overrides (per TEP-0085 patterns)
+5. Garbage collection via finalizers
+6. Pipeline-level external result declarations
+7. Tekton Chains integration testing
+8. Promote to beta
+
+### Phase 3: Production Ready (Stable)
+
+1. Caching layer for frequently accessed results
+2. Metrics and observability
+3. Integration with Tekton Results project
+4. Background garbage collector for orphaned results
+5. Promote to stable
+
+### Test Plan
+
+- Unit tests for each storage provider
+- Integration tests with mock storage
+- E2E tests with real storage backends (S3/MinIO, OCI registry)
+- Performance benchmarks comparing inline vs external results
+- Failure mode testing (storage unavailable, credentials expired, etc.)
+
+### Infrastructure Needed
+
+- CI/CD access to test storage backends (MinIO for S3, local registry for OCI)
+- Documentation updates for configuration
+- Example Tasks demonstrating external results
+
+### Upgrade and Migration Strategy
+
+- Feature is opt-in via result type declaration
+- No migration needed for existing Tasks/Pipelines
+- Feature flag allows gradual rollout
+- Existing inline results continue to work unchanged
+
+### Implementation Pull Requests
+
+<!-- To be filled as implementation progresses -->
+
+## References
+
+- [TEP-0085: Per-Namespace Controller Configuration](https://github.com/tektoncd/community/blob/main/teps/0085-per-namespace-controller-configuration.md)
+- [TEP-0086: Changing the Way Result Parameters are Stored](https://github.com/tektoncd/community/blob/main/teps/0086-changing-the-way-result-parameters-are-stored.md)
+- [TEP-0127: Larger Results via Sidecar Logs](https://github.com/tektoncd/community/blob/main/teps/0127-larger-results-via-sidecar-logs.md)
+- [Issue #4012: Changing the way Result Parameters are stored](https://github.com/tektoncd/pipeline/issues/4012)
+- [Issue #4808: Results, TerminationMessage and Containers](https://github.com/tektoncd/pipeline/issues/4808)
+- [Issue #8448: Enable larger results without a sidecar on every TaskRun](https://github.com/tektoncd/pipeline/issues/8448)
+- [Argo Workflows Artifacts](https://argo-workflows.readthedocs.io/en/latest/walk-through/artifacts/)
+- [tekton-caches: Pluggable storage backends](https://github.com/openshift-pipelines/tekton-caches)
+- [go-cloud/blob: Multi-cloud storage abstraction](https://github.com/google/go-cloud/tree/master/blob)
+- [ORAS: OCI Registry As Storage](https://oras.land/)
+- [Tekton Results Project](https://github.com/tektoncd/results)
+- [Tekton Chains](https://github.com/tektoncd/chains)

--- a/teps/0164-larger-results-via-external-storage.md
+++ b/teps/0164-larger-results-via-external-storage.md
@@ -1,17 +1,20 @@
 ---
-title: Larger Results via External Storage with Pluggable Backends
+title: "Tekton Artifacts Phase 2: External Storage for Artifacts and Results"
 authors:
   - "@vdemeester"
 creation-date: 2026-02-04
-last-updated: 2026-02-09
+last-updated: 2026-02-13
 status: proposed
+supersedes:
 see-also:
   - TEP-0085
   - TEP-0086
   - TEP-0127
+  - TEP-0139
+  - TEP-0147
 ---
 
-# TEP-0164: Larger Results via External Storage with Pluggable Backends
+# TEP-0164: Tekton Artifacts Phase 2 — External Storage for Artifacts and Results
 
 <!-- toc -->
 - [Summary](#summary)
@@ -21,17 +24,21 @@ see-also:
   - [Use Cases](#use-cases)
   - [Requirements](#requirements)
 - [Proposal](#proposal)
+  - [Relationship to TEP-0147 and TEP-0139](#relationship-to-tep-0147-and-tep-0139)
   - [Notes and Caveats](#notes-and-caveats)
 - [Design Details](#design-details)
-  - [New Result Type: external](#new-result-type-external)
-  - [Behavior When External Storage Is Not Configured](#behavior-when-external-storage-is-not-configured)
+  - [Extending ArtifactValue with Storage References](#extending-artifactvalue-with-storage-references)
+  - [Artifact Declaration in Task Spec](#artifact-declaration-in-task-spec)
+  - [Storage Modes](#storage-modes)
   - [Storage Backend Configuration](#storage-backend-configuration)
-  - [Namespace-Level Configuration](#namespace-level-configuration)
-  - [TaskRun Status with References](#taskrun-status-with-references)
+  - [Namespace-Level and Per-PipelineRun Configuration](#namespace-level-and-per-pipelinerun-configuration)
+  - [TaskRun Status with Storage References](#taskrun-status-with-storage-references)
   - [Transparent Resolution for Downstream Tasks](#transparent-resolution-for-downstream-tasks)
-  - [Init Container Injection for Large Results](#init-container-injection-for-large-results)
-  - [Pipeline-Level Result Declarations](#pipeline-level-result-declarations)
-  - [Integration with External Tools and Services](#integration-with-external-tools-and-services)
+  - [Init Container Injection for External Artifacts](#init-container-injection-for-external-artifacts)
+  - [Pipeline-Level Artifact Declarations](#pipeline-level-artifact-declarations)
+  - [OCI Artifact Grouping per PipelineRun](#oci-artifact-grouping-per-pipelinerun)
+  - [Integration with Tekton Chains](#integration-with-tekton-chains)
+  - [Integration with Tekton Results and UIs](#integration-with-tekton-results-and-uis)
   - [Storage Provider Interface](#storage-provider-interface)
   - [Supported Backends](#supported-backends)
   - [Garbage Collection](#garbage-collection)
@@ -46,8 +53,9 @@ see-also:
   - [Drawbacks](#drawbacks)
 - [Alternatives](#alternatives)
   - [TEP-0127: Sidecar Logs](#tep-0127-sidecar-logs)
+  - [TEP-0139: Injected Trusted Steps with PVC](#tep-0139-injected-trusted-steps-with-pvc)
+  - [Standalone External Results (Original TEP-0164)](#standalone-external-results-original-tep-0164)
   - [ConfigMaps per TaskRun](#configmaps-per-taskrun)
-  - [Custom CRD for Results](#custom-crd-for-results)
   - [Workspaces Only](#workspaces-only)
 - [Implementation Plan](#implementation-plan)
   - [Test Plan](#test-plan)
@@ -59,68 +67,92 @@ see-also:
 
 ## Summary
 
-This TEP proposes a new approach to handling large Task results by introducing
-external storage backends with pluggable providers. Instead of storing large
-result values directly in the TaskRun status (limited by Kubernetes CRD size
-constraints), this proposal allows results to be stored in external storage
-systems (S3, GCS, OCI registries, etc.) while only storing a reference in
-the TaskRun status.
+This TEP extends [TEP-0147 (Tekton Artifacts Phase
+1)](https://github.com/tektoncd/community/blob/main/teps/0147-tekton-artifacts-phase1.md)
+with external storage backends, unifying two related problems:
 
-This approach provides:
-- **No per-pod overhead**: Unlike TEP-0127's sidecar approach, no additional
-  containers are injected into TaskRun pods
-- **Truly unlimited result sizes**: Limited only by the external storage backend
-- **Per-result opt-in**: Only results marked as `type: external` use external
-  storage; existing behavior remains unchanged for inline results
-- **Pluggable backends**: Operators can configure their preferred storage
-  backend (S3, GCS, OCI registry, Azure Blob, PVC)
-- **Transparent resolution**: Downstream tasks can reference external results
-  using the same syntax as inline results
+1. **Larger Results**: Overcoming the 4KB/12KB termination message limits and
+   ~1.5MB CRD size constraints that prevent Tasks from producing results of
+   meaningful size.
+
+2. **Trusted Artifacts**: Establishing a chain of trust for data shared between
+   Tasks, as proposed in [TEP-0139](https://github.com/tektoncd/community/blob/main/teps/0139-trusted-artifacts.md),
+   by combining verified storage with artifact provenance metadata.
+
+TEP-0147 Phase 1 (implemented, alpha) provides the artifact provenance
+structure — `ArtifactValue` with `Uri` and `Digest` fields — and the
+`$(step.artifacts.path)` API for reporting artifact metadata. However, it has
+**no storage backend**: artifacts are referenced but not managed by Tekton.
+
+This TEP adds the missing storage layer and the declarative Artifact API
+proposed in TEP-0139. By extending `ArtifactValue` with a `StorageRef` and
+introducing `spec.artifacts.inputs/outputs` on Tasks, we enable Tekton to
+upload, download, verify, and manage artifact content through pluggable
+backends (OCI registry, S3, GCS, PVC). This solves the results size problem,
+the trusted artifacts problem, and the artifact declaration problem with a
+single, unified design.
 
 ## Motivation
 
-Tekton Results are currently severely constrained by Kubernetes limitations:
+### Current Limitations
 
-1. **Termination Message Limit**: Results are stored via container termination
-   messages, limited to 4KB per container and 12KB total per Pod across all
-   containers.
+Tekton Results are severely constrained by Kubernetes limitations:
 
-2. **Container Count Impact**: The more Steps in a Task, the smaller
-   each result can be. For example, with 12 containers in a pod, each
-   container gets only ~1KB for its termination message.
+1. **Termination Message Limit**: Results stored via container termination
+   messages are limited to 4KB per container and 12KB total per Pod.
 
-3. **CRD Size Limit**: Even with TEP-0127's sidecar logs approach, results
-   ultimately end up in the TaskRun status, subject to the ~1.5MB CRD size
-   limit.
+2. **Container Count Impact**: More Steps in a Task means less space per
+   result. With 12 containers, each gets only ~1KB.
 
-These limitations significantly impact real-world use cases:
+3. **CRD Size Limit**: Even with TEP-0127's sidecar logs, results end up in
+   TaskRun status, subject to the ~1.5MB CRD size limit.
 
-- **Tekton Chains**: Signing multiple container images produces large lists
-  of digest-pinned image references that exceed result limits
-- **SBOM Generation**: Software Bill of Materials documents are typically
-  10KB-10MB in size
-- **Build Manifests**: Multi-architecture build manifests listing all produced
-  artifacts
-- **JSON API Responses**: Tasks that fetch or transform JSON data between steps
+4. **No Storage for Artifacts**: TEP-0147 provides provenance metadata
+   (`Uri` + `Digest`) but no mechanism to actually store or retrieve artifact
+   content. Steps must handle their own upload/download.
+
+5. **No Trust Chain**: Without Tekton-managed storage, there is no built-in
+   verification that artifacts passed between Tasks have not been tampered
+   with (the problem TEP-0139 identifies).
+
+### Convergence Opportunity
+
+Three related TEPs address overlapping concerns:
+
+| TEP | Focus | Status | Has Provenance | Has Storage |
+|-----|-------|--------|----------------|-------------|
+| [TEP-0147](https://github.com/tektoncd/community/blob/main/teps/0147-tekton-artifacts-phase1.md) | Artifact provenance metadata | Implemented (alpha) | ✅ Uri + Digest | ❌ |
+| [TEP-0139](https://github.com/tektoncd/community/blob/main/teps/0139-trusted-artifacts.md) | Trusted artifact sharing | Proposed | ✅ (references 0147) | ✅ (conceptual) |
+| TEP-0164 (this) | External storage + Artifact API | Proposed | ✅ (extends 0147) | ✅ (concrete) |
+
+Rather than three separate systems, this TEP unifies them: **TEP-0147's
+provenance structure + TEP-0139's Artifact API + external storage backends =
+trusted artifacts with arbitrary size support and a declarative API**.
 
 ### Goals
 
-1. Enable Tasks to produce results of arbitrary size without impacting TaskRun
-   pod overhead
-2. Provide a pluggable storage backend system that operators can configure
-3. Maintain backward compatibility with existing inline results
-4. Allow per-result opt-in to external storage
-5. Ensure transparent resolution so downstream tasks can consume external
-   results without special handling
-6. Support integrity verification via content digests
+1. **Extend TEP-0147** with pluggable storage backends for artifact content.
+2. **Implement TEP-0139's Artifact API** — declarative `spec.artifacts.inputs`
+   and `spec.artifacts.outputs` on Tasks, with Pipeline-level artifact binding.
+3. Enable Tasks to produce and consume **artifacts of arbitrary size**.
+4. Provide a **chain of trust** for artifacts shared between Tasks via
+   digest verification on upload and download.
+5. Maintain **backward compatibility** with existing inline results and
+   TEP-0147 Phase 1 artifact reporting.
+6. Support **transparent resolution** so downstream Tasks consume artifacts
+   without special handling.
+7. Align with **production patterns** from Konflux CI's OCI-based trusted
+   artifacts.
 
 ### Non-Goals
 
-1. Replacing Tekton Results project - this TEP focuses on inter-task result
-   passing, not long-term storage and querying
-2. Automatic result streaming or real-time result access during Task execution
-3. Providing a general-purpose artifact storage system (use Workspaces for that)
-4. Solving the termination message limit for inline results (that remains at 4KB)
+1. Replacing Tekton Results project — this TEP focuses on inter-task artifact
+   passing, not long-term storage and querying.
+2. Automatic artifact streaming or real-time access during Task execution.
+3. Solving the termination message limit for inline results (that remains
+   at 4KB).
+4. Auto-provisioning of artifact storage (e.g., automatic PVC creation) — operators
+   configure storage backends explicitly.
 
 ### Use Cases
 
@@ -128,102 +160,7 @@ These limitations significantly impact real-world use cases:
 
 A Task builds multiple container images and needs to pass the list of all
 image references (with digests) to a signing Task. With 20+ images, the
-result easily exceeds 4KB.
-
-```yaml
-# build-images Task
-results:
-  - name: IMAGES
-    type: external
-    description: JSON array of built image references with digests
-
-# sign-images Task
-params:
-  - name: images
-    value: $(tasks.build-images.results.IMAGES)
-```
-
-**Use Case 2: SBOM Generation**
-
-A Task generates an SBOM in SPDX or CycloneDX format that needs to be
-passed to an attestation Task.
-
-```yaml
-results:
-  - name: sbom
-    type: external
-    description: SPDX SBOM document
-```
-
-**Use Case 3: Test Results Processing**
-
-A test Task produces detailed JUnit XML output that needs to be processed
-by a reporting Task.
-
-```yaml
-results:
-  - name: junit-report
-    type: external
-    description: JUnit XML test results
-```
-
-### Requirements
-
-**Must Have:**
-
-1. **Backward Compatibility**: Existing Tasks and Pipelines must continue to
-   work without modification
-2. **Opt-in**: External storage must be explicitly requested per-result
-3. **Configurable**: Operators must be able to configure storage backends
-   at the cluster level
-4. **Secure**: Credentials for storage backends must be handled securely
-5. **Verifiable**: Result integrity must be verifiable via content digests
-6. **Clear failure modes**: When external storage is not configured but
-   `type: external` is used, the failure must be immediate and obvious
-
-**Nice to Have (can be deferred):**
-
-7. **Garbage Collection**: External results should be cleanable when TaskRuns
-   are deleted. For MVP, operators can rely on storage lifecycle policies.
-8. **Namespace-level configuration**: Per-namespace storage backend overrides
-
-## Proposal
-
-Introduce a new result type `external` that stores result content in a
-configured external storage backend and stores only a reference (with digest)
-in the TaskRun status.
-
-The key components are:
-
-1. **New Result Type**: `type: external` in Task spec
-2. **Storage Backend Configuration**: Cluster-level ConfigMap for default
-   backend, with optional namespace-level overrides
-3. **Reference Storage**: TaskRun status stores a reference object instead
-   of the full value
-4. **Transparent Resolution**: The entrypoint binary and controller handle
-   fetching external results when needed by downstream tasks
-5. **Pluggable Provider Interface**: Go interface that storage providers
-   implement
-
-### Notes and Caveats
-
-- External storage requires additional infrastructure (S3 bucket, GCS bucket,
-  or OCI registry)
-- Network latency for fetching external results may impact Pipeline execution
-  time
-- Storage credentials must be available to:
-  - TaskRun pods (for uploading results via entrypoint)
-  - Tekton Pipelines controller (for resolving results in downstream tasks)
-  - External tools/services that consume results (e.g., Tekton Chains for
-    attestation, Tekton Results for long-term storage)
-- Tasks declaring `type: external` results will fail validation on clusters
-  without external storage configured
-
-## Design Details
-
-### New Result Type: external
-
-Tasks can declare results with `type: external`:
+artifact data easily exceeds 4KB.
 
 ```yaml
 apiVersion: tekton.dev/v1
@@ -231,197 +168,568 @@ kind: Task
 metadata:
   name: build-images
 spec:
-  results:
-    - name: digest
-      type: string           # inline, current behavior (default)
-      description: Primary image digest
-    - name: IMAGES
-      type: external         # NEW: stored externally
-      description: JSON array of all built images with digests
-    - name: sbom
-      type: external
-      description: SPDX SBOM document
-      properties:
-        maxSize: 10Mi        # optional: hint for storage allocation
+  artifacts:
+    outputs:
+      - name: images
+        description: Built image references with digests
+        buildOutput: true
+        storage: external
   steps:
     - name: build
       image: builder:latest
       script: |
-        # Small result - written to inline result path
-        echo -n "sha256:abc123..." > $(results.digest.path)
-
-        # Large results - written to external result path (same API)
-        cat images.json > $(results.IMAGES.path)
-        cat sbom.spdx.json > $(results.sbom.path)
+        # Build images, write output to artifact path
+        # Tekton handles upload, digest, and provenance automatically
+        cat images.json > $(outputs.images.path)
 ```
 
-The Task author experience is identical - results are written to the same
-paths. The difference is in how the entrypoint handles them.
+```yaml
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: sign-images
+spec:
+  artifacts:
+    inputs:
+      - name: images
+        description: Image references to sign
+  steps:
+    - name: sign
+      image: cosign:latest
+      script: |
+        # Content is fetched and verified by init container before this runs
+        cat $(inputs.images.path) | jq -r '.[].uri' | while read ref; do
+          cosign sign "$ref"
+        done
+```
 
-### Behavior When External Storage Is Not Configured
+```yaml
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: build-and-sign
+spec:
+  tasks:
+    - name: build
+      taskRef:
+        name: build-images
+    - name: sign
+      taskRef:
+        name: sign-images
+      artifacts:
+        inputs:
+          - name: images
+            from: tasks.build.outputs.images
+```
 
-A key design question is: what happens when a Task declares `type: external`
-for a result, but the cluster has no external storage backend configured?
+**Use Case 2: SBOM Generation with Signing**
 
-**Proposed behavior:**
+An SBOM is a large document (10KB-10MB) that should be **stored externally
+and referenced**, not passed inline as text. A downstream Task can then sign
+or attest the SBOM using its digest — without Tekton duplicating the entire
+document in the attestation.
 
-1. **Validation at admission time**: When a Task or TaskRun with `type: external`
-   results is submitted and the feature flag `enable-external-results` is not
-   enabled or no backend is configured, the controller should reject the
-   resource with a clear error message:
+```yaml
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: generate-sbom
+spec:
+  params:
+    - name: image
+  artifacts:
+    outputs:
+      - name: sbom
+        description: SPDX SBOM document
+        storage: external
+  steps:
+    - name: generate
+      image: syft:latest
+      script: |
+        syft scan $(params.image) -o spdx-json > $(outputs.sbom.path)
+        # Tekton computes digest and uploads automatically
+```
 
-   ```
-   Error: Task "build-images" declares external result "IMAGES" but external
-   result storage is not configured. Either configure a storage backend in
-   config-result-storage ConfigMap or change the result type to "string".
-   ```
+The signing Task receives the SBOM reference (URI + digest) via the artifact
+binding and can verify integrity before signing. Chains records only the
+digest in the attestation, not the full SBOM content.
 
-2. **Feature flag gating**: The `type: external` result type is only valid when
-   the `enable-external-results` feature flag is set to `"true"`. This ensures
-   Tasks using external results are only accepted on clusters that support them.
+**Use Case 3: ML Model Passing (Kubeflow Pipelines)**
 
-3. **Graceful degradation option** (future consideration): An optional
-   `fallback-to-inline: "true"` configuration could allow external results to
-   fall back to inline storage if the content is small enough. This would be
-   useful during migration periods.
+Kubeflow Pipelines on Tekton (kfp-tekton) needs to pass large ML artifacts
+(datasets, models, metrics) between pipeline steps. Currently constrained
+by the 4KB result limit, requiring workarounds with Workspaces and PVCs.
 
-This approach ensures that:
-- Tasks are portable: they clearly declare their requirements
-- Failures are fast and obvious: no silent data loss or truncation
-- Operators have clear guidance on what configuration is needed
+```yaml
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: train-model
+spec:
+  artifacts:
+    inputs:
+      - name: dataset
+        description: Training dataset
+    outputs:
+      - name: model
+        description: Trained model weights
+        storage: external
+      - name: metrics
+        description: Training metrics (small)
+        storage: inline
+  steps:
+    - name: train
+      image: tensorflow:latest
+      script: |
+        python train.py \
+          --data $(inputs.dataset.path) \
+          --output $(outputs.model.path)
+        # Write small metrics inline
+        echo '{"accuracy": 0.95, "loss": 0.05}' > $(outputs.metrics.path)
+```
+
+**Use Case 4: Test Results Processing**
+
+A test Task produces detailed JUnit XML output (potentially large) that
+needs to be processed by a reporting Task.
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: run-tests
+spec:
+  artifacts:
+    outputs:
+      - name: test-results
+        description: JUnit XML test results
+        storage: external
+  steps:
+    - name: test
+      image: maven:latest
+      script: |
+        mvn test
+        cp target/surefire-reports/*.xml $(outputs.test-results.path)/
+```
+
+### Requirements
+
+**Must Have:**
+
+1. **Backward Compatibility**: Existing Tasks, Pipelines, and TEP-0147
+   Phase 1 artifact reporting must continue to work unchanged.
+2. **Extends TEP-0147**: Builds on the existing `ArtifactValue` structure
+   rather than introducing a parallel system.
+3. **Declarative Artifact API**: Tasks declare `spec.artifacts.inputs` and
+   `spec.artifacts.outputs` with `$(inputs.name.path)` / `$(outputs.name.path)`
+   variables (adopting TEP-0139's design).
+4. **Pluggable Backends**: Operators configure their preferred storage
+   (OCI registry, S3, GCS, PVC).
+5. **Digest Verification**: Content integrity verified on both upload and
+   download (chain of trust).
+6. **Transparent Resolution**: Downstream Tasks consume artifacts via
+   declarative bindings or variable substitution.
+7. **Reference-Based**: Only references (URI + digest) stored in TaskRun
+   status; actual content lives in external storage.
+
+**Nice to Have (can be deferred):**
+
+7. **Garbage Collection**: Automated cleanup of external artifacts.
+8. **OCI Artifact Grouping**: Group artifacts per PipelineRun using OCI
+   referrers.
+9. **Caching**: OCI layer caching for frequently accessed artifacts.
+
+## Proposal
+
+Extend TEP-0147's `ArtifactValue` type with a storage reference and adopt
+TEP-0139's declarative Artifact API, enabling Tekton to manage artifact
+content in external storage while providing a first-class API for declaring,
+producing, and consuming artifacts.
+
+The key insight is that TEP-0147 already provides the right data structure
+for artifact provenance (`Uri` + `Digest`), and TEP-0139 already designed
+the right user-facing API (`spec.artifacts.inputs/outputs`). What's missing
+is:
+
+1. A **storage backend** that Tekton manages (upload/download/verify)
+2. A **reference** from `ArtifactValue` to the stored content
+3. **Metadata** about the stored content (size, content type)
+4. An option for **inline** small content (avoiding external storage overhead
+   for small artifacts)
+5. A **declarative API** for Tasks to declare input/output artifacts upfront
+
+### Relationship to TEP-0147 and TEP-0139
+
+This TEP is explicitly designed as **TEP-0147 Phase 2** and a concrete
+implementation of **TEP-0139's goals**:
+
+| Aspect | TEP-0147 Phase 1 | TEP-0139 (proposed) | This TEP (Phase 2) |
+|--------|-------------------|---------------------|---------------------|
+| Artifact provenance | ✅ `{Uri, Digest}` | ✅ `{uri, digest}` | ✅ Extended with `{Ref, Size, Inline}` |
+| Declarative API | ❌ | ✅ `spec.inputs/outputs` | ✅ `spec.artifacts.inputs/outputs` |
+| Step API | ✅ `$(step.artifacts.path)` | ✅ (provenance files) | ✅ Same + `$(outputs.name.path)` |
+| Task-level artifacts | ✅ `$(artifacts.path)` | ✅ | ✅ Same API |
+| Pipeline binding | ✅ `$(tasks.name.outputs.art)` | ✅ `inputs: [{value: $(tasks...)}]` | ✅ Both syntaxes |
+| Storage management | ❌ User-managed | ✅ PVC + injected Steps | ✅ Pluggable backends (OCI/S3/GCS/PVC) |
+| Trust mechanism | ❌ | ✅ Injected digest/upload/download/verify Steps | ✅ Entrypoint + init container (transparent) |
+| Size limits | ❌ Termination msg | ❌ PVC/node disk | ✅ Unlimited (backend-dependent) |
+
+**What we adopt from TEP-0139:**
+
+1. **Declarative Artifact API** — Tasks declare `spec.artifacts.inputs` and
+   `spec.artifacts.outputs` upfront, with `$(inputs.name.path)` and
+   `$(outputs.name.path)` variables for Steps to read/write artifact content.
+2. **Pipeline-level artifact binding** — Pipelines connect Tasks by piping
+   outputs to inputs: `inputs: [{name: bar, from: tasks.producer.outputs.foo}]`.
+3. **Chain of trust** — digest verification on both upload and download,
+   ensuring artifacts have not been tampered with between Tasks.
+4. **Provenance integration** — artifact metadata flows into TaskRun status
+   and Tekton Chains attestations.
+
+**Where we differ from TEP-0139:**
+
+1. **No injected Steps** — TEP-0139 injects 4 Steps (digest, upload, download,
+   verify) into the Pod. This adds visible overhead and complexity. Instead,
+   we handle storage operations transparently in the entrypoint binary (upload)
+   and init container (download + verify).
+2. **External storage, not just PVC** — TEP-0139 focuses on PVC-based sharing
+   with a single Workspace. We support pluggable backends (OCI, S3, GCS, PVC),
+   which removes the PVC/node disk size limitation and enables cross-cluster
+   artifact sharing.
+3. **No Artifact Workspace auto-provisioning** — TEP-0139 proposes automatic
+   PVC provisioning for artifact sharing. We require operators to configure
+   storage backends explicitly, which is simpler and more predictable.
+4. **Content format** — TEP-0139 stores artifacts as tarballs (`<digest>.tgz`)
+   on PVC. We store content as-is in external storage (OCI layers, S3 objects),
+   which is more natural for each backend.
+
+### Notes and Caveats
+
+- External storage requires additional infrastructure (OCI registry, S3
+  bucket, etc.)
+- Network latency for fetching artifacts may impact Pipeline execution time
+- Storage credentials must be available to TaskRun pods and the controller
+- Tasks using external storage will fail on clusters without it configured
+- Two artifact authoring APIs coexist:
+  - **Declarative** (`spec.artifacts` + `$(outputs.name.path)`): recommended,
+    Tekton manages everything
+  - **Provenance-only** (`$(step.artifacts.path)` JSON): TEP-0147 Phase 1
+    backward compatibility, Steps manage their own storage
+- The declarative API mirrors TEP-0139's design but uses different storage
+  mechanisms (external backends instead of injected Steps + PVC)
+
+## Design Details
+
+### Extending ArtifactValue with Storage References
+
+The core API change extends TEP-0147's `ArtifactValue` type:
+
+```go
+// ArtifactValue represents a specific value or data element within an Artifact.
+// Extended from TEP-0147 Phase 1 with storage reference support.
+type ArtifactValue struct {
+    // Existing TEP-0147 fields
+    Digest map[Algorithm]string `json:"digest,omitempty"`
+    Uri    string               `json:"uri,omitempty"`
+
+    // NEW: External storage reference
+    Ref    *StorageRef          `json:"ref,omitempty"`
+
+    // NEW: Content size in bytes
+    Size   int64                `json:"size,omitempty"`
+
+    // NEW: Small content inline (avoids external storage for small artifacts)
+    Inline string               `json:"inline,omitempty"`
+}
+
+// StorageRef identifies content in an external storage backend.
+type StorageRef struct {
+    // Backend type: oci, s3, gcs, azure, pvc
+    Backend string `json:"backend"`
+
+    // Backend-specific location
+    // OCI: "registry.example.com/tekton/artifacts:tag"
+    // S3:  "bucket/key"
+    // PVC: "pvc-name/path"
+    Location string `json:"location"`
+
+    // Content digest for integrity verification (redundant with ArtifactValue.Digest
+    // but included for self-contained reference resolution)
+    Digest string `json:"digest"`
+
+    // Content type hint (e.g., "application/json", "application/spdx+json")
+    ContentType string `json:"contentType,omitempty"`
+}
+```
+
+**Design rationale:**
+
+- `Ref` is a pointer (optional) — `ArtifactValue` without a `Ref` behaves
+  exactly as in TEP-0147 Phase 1.
+- `Size` enables consumers to know artifact size before fetching.
+- `Inline` allows small content to be embedded directly, avoiding external
+  storage overhead. This replaces the need for `type: string` results when
+  content is small but should still participate in the artifact provenance
+  system.
+- The `Digest` in both `ArtifactValue` and `StorageRef` enables verification
+  at both the provenance and storage levels.
+
+### Artifact Declaration in Task Spec
+
+This TEP introduces a declarative Artifact API on Tasks, adopting the design
+from TEP-0139. Tasks can declare input and output artifacts upfront, similar
+to how they declare parameters and results today.
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: build-images
+spec:
+  artifacts:
+    inputs:
+      - name: source
+        description: Source code to build
+    outputs:
+      - name: images
+        description: Built container image references
+        buildOutput: true    # Chains treats as SLSA subject (not byProduct)
+        storage: external    # hint: use external storage
+      - name: build-log
+        description: Build summary log
+        storage: inline      # hint: keep inline (small)
+  steps:
+    - name: build
+      image: builder:latest
+      env:
+        - name: SOURCE_PATH
+          value: $(inputs.source.path)    # resolves to /tekton/artifacts/inputs/source/
+      script: |
+        # Read input artifacts
+        ls ${SOURCE_PATH}
+
+        # Produce output artifacts by writing to the output path
+        cat images.json > $(outputs.images.path)
+        echo "Build completed: 2 images" > $(outputs.build-log.path)
+```
+
+**Variables available to Steps:**
+
+| Variable | Resolves to | Description |
+|----------|-------------|-------------|
+| `$(inputs.<name>.path)` | `/tekton/artifacts/inputs/<name>/` | Directory for input artifact content |
+| `$(inputs.<name>.uri)` | URI string | Artifact URI from upstream producer |
+| `$(inputs.<name>.digest)` | Digest string | Artifact digest from upstream producer |
+| `$(outputs.<name>.path)` | `/tekton/artifacts/outputs/<name>/` | Directory for output artifact content |
+
+When a Step writes content to `$(outputs.<name>.path)`, the entrypoint
+binary handles the rest:
+1. Computes the content digest
+2. Uploads to external storage (if configured and content exceeds threshold)
+3. Generates provenance metadata (`uri`, `digest`) for the TaskRun status
+
+This is a higher-level API than TEP-0147 Phase 1's `$(step.artifacts.path)`
+where Steps had to write provenance JSON manually. Both APIs coexist:
+
+- **Declarative API** (`spec.artifacts` + `$(outputs.name.path)`): Tekton
+  manages storage, digest, and provenance automatically. Recommended for new
+  Tasks.
+- **Provenance-only API** (`$(step.artifacts.path)` JSON): Steps handle their
+  own storage and write provenance metadata manually. Preserved for backward
+  compatibility with TEP-0147 Phase 1 Tasks.
+
+**The `storage` field** is a hint, not a hard requirement. The entrypoint
+binary decides based on content size and cluster configuration:
+
+| `storage` hint | Content ≤ threshold | Content > threshold |
+|----------------|---------------------|---------------------|
+| `inline` | Stored inline | Error (content too large) |
+| `external` | Stored externally | Stored externally |
+| (not set) | Stored inline | Stored externally if configured, error if not |
+
+**Backward compatibility:** Existing TEP-0147 Phase 1 Tasks (without
+`spec.artifacts`) continue to work unchanged. The entrypoint only uses
+the new storage path when `spec.artifacts` is declared.
+
+### Storage Modes
+
+Artifacts can be stored in three modes:
+
+1. **Inline**: Content embedded in `ArtifactValue.Inline` field (current
+   behavior, small artifacts). Subject to termination message limits.
+
+2. **External**: Content uploaded to configured storage backend. Only
+   `StorageRef` stored in TaskRun status.
+
+3. **Reference-only**: No content managed by Tekton — only `Uri` + `Digest`
+   recorded (pure TEP-0147 Phase 1 behavior). Used when Steps handle their
+   own storage.
+
+The entrypoint determines the mode based on:
+1. Task spec `storage` hint (if declared)
+2. Content size vs inline threshold (configurable, default 1KB)
+3. Whether external storage is configured on the cluster
 
 ### Storage Backend Configuration
 
-Cluster-level default configuration via ConfigMap:
+Cluster-level configuration via ConfigMap:
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: config-result-storage
+  name: config-artifact-storage
   namespace: tekton-pipelines
 data:
-  # Enable external result storage (default: "false")
+  # Enable external artifact storage (default: "false")
   enabled: "true"
 
-  # Default backend type: s3, gcs, oci, azure, pvc
-  backend: "s3"
+  # Default backend type: oci, s3, gcs, azure, pvc
+  backend: "oci"
 
-  # S3 configuration
-  s3.bucket: "tekton-results"
-  s3.region: "us-east-1"
-  s3.endpoint: ""                    # optional, for MinIO/other S3-compatible
-  s3.pathStyle: "false"              # set to "true" for MinIO
-  s3.credentialsSecret: "tekton-results-s3-creds"
+  # Inline threshold: artifacts smaller than this are stored inline
+  # regardless of storage hint (default: "1024" bytes)
+  inline-threshold: "1024"
 
-  # Key pattern for storing results
-  # Available variables: {{namespace}}, {{taskrun}}, {{result}}
-  keyPattern: "{{namespace}}/{{taskrun}}/{{result}}"
+  # OCI Registry configuration
+  oci.repository: "registry.example.com/tekton/artifacts"
+  oci.credentialsSecret: "tekton-artifact-oci-creds"
+
+  # Tag pattern for storing artifacts
+  # Available variables: {{namespace}}, {{pipelinerun}}, {{taskrun}}, {{artifact}}
+  oci.tagPattern: "{{namespace}}-{{taskrun}}-{{artifact}}"
 ```
 
 Alternative backend configurations:
 
 ```yaml
+# S3 configuration
+data:
+  backend: "s3"
+  s3.bucket: "tekton-artifacts"
+  s3.region: "us-east-1"
+  s3.endpoint: ""                    # optional, for MinIO/S3-compatible
+  s3.pathStyle: "false"              # "true" for MinIO
+  s3.credentialsSecret: "tekton-artifact-s3-creds"
+  # Key pattern
+  s3.keyPattern: "{{namespace}}/{{taskrun}}/{{artifact}}"
+
 # GCS configuration
 data:
   backend: "gcs"
-  gcs.bucket: "tekton-results"
-  gcs.credentialsSecret: "tekton-results-gcs-creds"
-  gcs.credentialsKey: "service-account.json"
+  gcs.bucket: "tekton-artifacts"
+  gcs.credentialsSecret: "tekton-artifact-gcs-creds"
 
-# OCI Registry configuration
+# PVC configuration (no external infrastructure needed)
 data:
-  backend: "oci"
-  oci.registry: "registry.example.com"
-  oci.repository: "tekton/results"
-  oci.credentialsSecret: "tekton-results-oci-creds"
-
-# Azure Blob configuration
-data:
-  backend: "azure"
-  azure.container: "tekton-results"
-  azure.accountName: "tektonresults"
-  azure.credentialsSecret: "tekton-results-azure-creds"
+  backend: "pvc"
+  pvc.claimName: "tekton-artifacts"
+  pvc.basePath: "/artifacts"
 ```
 
-### Namespace-Level Configuration
+### Namespace-Level and Per-PipelineRun Configuration
 
-In addition to cluster-level defaults, operators may want to configure
-different storage backends per namespace. This is particularly useful in
-multi-tenant environments where different teams have different storage
-requirements or credentials.
-
-Namespace-level configuration follows the patterns established in
-[TEP-0085: Per-Namespace Controller Configuration](https://github.com/tektoncd/community/blob/main/teps/0085-per-namespace-controller-configuration.md).
+**Namespace-level** configuration overrides follow [TEP-0085](https://github.com/tektoncd/community/blob/main/teps/0085-per-namespace-controller-configuration.md):
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: config-result-storage
-  namespace: team-a  # Namespace-specific override
+  name: config-artifact-storage
+  namespace: team-a
   labels:
-    tekton.dev/config-type: result-storage
+    tekton.dev/config-type: artifact-storage
 data:
   backend: "oci"
-  oci.registry: "team-a-registry.example.com"
-  oci.repository: "tekton/results"
+  oci.repository: "team-a-registry.example.com/artifacts"
   oci.credentialsSecret: "team-a-registry-creds"
 ```
 
-The controller resolves configuration in the following order:
-1. Namespace-level ConfigMap (if exists)
-2. Cluster-level ConfigMap in `tekton-pipelines` namespace
-3. Built-in defaults (external results disabled)
+**Per-PipelineRun** configuration via annotations, allowing credentials to be
+derived from the ServiceAccount bound to the PipelineRun:
 
-### TaskRun Status with References
+```yaml
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: my-pipeline-run
+  annotations:
+    tekton.dev/artifact-storage-backend: "oci"
+    tekton.dev/artifact-storage-oci-repository: "my-registry.example.com/artifacts"
+spec:
+  serviceAccountName: my-sa  # SA credentials used for OCI auth
+  pipelineRef:
+    name: build-and-sign
+```
 
-When a TaskRun completes with external results, the status contains references:
+Resolution order:
+1. PipelineRun annotations (if set)
+2. Namespace-level ConfigMap (if exists)
+3. Cluster-level ConfigMap in `tekton-pipelines` namespace
+4. Built-in defaults (external storage disabled)
+
+### TaskRun Status with Storage References
+
+When a TaskRun completes with externally stored artifacts, the status
+contains extended `ArtifactValue` entries with storage references:
 
 ```yaml
 apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: build-images-run-abc123
-spec:
-  taskRef:
-    name: build-images
 status:
   conditions:
     - type: Succeeded
       status: "True"
+  # Existing inline results (unchanged)
   results:
-    # Inline result - stored directly
-    - name: digest
+    - name: commit
       type: string
-      value: "sha256:abc123def456..."
-
-    # External result - reference only
-    - name: IMAGES
-      type: external
-      ref:
-        backend: s3
-        bucket: tekton-results
-        key: "default/build-images-run-abc123/IMAGES"
-        digest: "sha256:789xyz..."
-        size: 45678
-        contentType: "application/json"
-
-    # Another external result
-    - name: sbom
-      type: external
-      ref:
-        backend: s3
-        bucket: tekton-results
-        key: "default/build-images-run-abc123/sbom"
-        digest: "sha256:def789..."
-        size: 2457600
-        contentType: "application/spdx+json"
+      value: "abc123def"
+  # Artifact provenance with storage references
+  steps:
+    - container: step-build
+      outputs:
+        - name: images
+          buildOutput: true
+          values:
+            - uri: "pkg:docker/myapp@sha256:abc123"
+              digest:
+                sha256: "abc123..."
+              ref:
+                backend: oci
+                location: "registry.example.com/tekton/artifacts:default-build-images-run-abc123-images"
+                digest: "sha256:abc123..."
+                contentType: "application/json"
+              size: 45678
+            - uri: "pkg:docker/myapp@sha256:def456"
+              digest:
+                sha256: "def456..."
+        - name: build-log
+          values:
+            - uri: "pkg:generic/build-log"
+              digest:
+                sha256: "789xyz..."
+              inline: "Build completed: 2 images, 0 errors"  # Small, stored inline
 ```
+
+Note how:
+- Artifacts with `ref` have their content in external storage
+- Artifacts with `inline` have small content embedded directly
+- Artifacts with neither (just `uri` + `digest`) are pure provenance
+  references (TEP-0147 Phase 1 behavior)
+- The existing `results` field continues to work for traditional inline
+  results
 
 ### Transparent Resolution for Downstream Tasks
 
-Downstream tasks reference external results using the standard syntax:
+Downstream Tasks consume artifacts through two complementary mechanisms:
+
+**1. Declarative Artifact Binding (recommended)**
+
+When both producer and consumer Tasks declare `spec.artifacts`, the Pipeline
+connects them directly through artifact bindings:
 
 ```yaml
 apiVersion: tekton.dev/v1
@@ -437,76 +745,88 @@ spec:
     - name: sign
       taskRef:
         name: sign-images
-      params:
-        - name: images
-          # Same syntax - controller resolves external reference
-          value: $(tasks.build.results.IMAGES)
-      runAfter:
-        - build
+      artifacts:
+        inputs:
+          - name: images
+            from: tasks.build.outputs.images
+      # runAfter is implicit — artifact dependency creates DAG edge
 
     - name: attest
       taskRef:
         name: create-attestation
-      params:
-        - name: sbom
-          value: $(tasks.build.results.sbom)
-      runAfter:
-        - build
+      artifacts:
+        inputs:
+          - name: sbom
+            from: tasks.build.outputs.sbom
 ```
 
-The PipelineRun controller:
+When an artifact binding is declared, the PipelineRun controller:
 
-1. Detects that `$(tasks.build.results.IMAGES)` references an external result
+1. Creates a DAG edge (implicit `runAfter`) between producer and consumer
 2. Injects an init container to fetch the content from storage
-3. Substitutes the result reference with the file path where content is available
+3. Verifies the content digest matches the reference
+4. Mounts content at `$(inputs.<name>.path)` before user Steps execute
 
-### Init Container Injection for External Results
+**2. Variable Substitution (TEP-0147 Phase 1 compatible)**
 
-All external results use an init container approach for downstream resolution.
-This provides a consistent, simple model: `type: external` results are always
-file-based, while `type: string` results remain inline.
+For Tasks that don't use the declarative API (or for passing artifact
+metadata as parameters), the existing variable substitution syntax works:
 
-**How it works:**
+```yaml
+    - name: notify
+      taskRef:
+        name: send-notification
+      params:
+        - name: images-digest
+          # TEP-0147 syntax — resolves to provenance metadata (JSON string)
+          value: $(tasks.build.outputs.images)
+```
 
-1. **Init container injection**: The controller injects an init container into
-   downstream TaskRun pods that:
-   - Fetches the external result content from storage
-   - Writes it to a shared emptyDir volume at a well-known path
-   - Verifies the content digest matches the reference
+This resolves to the serialized JSON `values` array, as in TEP-0147 Phase 1.
+It passes provenance metadata (URI + digest), not the full content. Tasks
+using this pattern must handle content fetching themselves.
 
-2. **File path substitution**: The controller substitutes result references
-   with file paths:
+### Init Container Injection for External Artifacts
 
-   ```yaml
-   # Original parameter reference
-   value: $(tasks.build.results.sbom)
+When a downstream Task needs artifact content from external storage, the
+controller injects an init container that:
 
-   # Becomes
-   value: /tekton/results/external/build/sbom
-   ```
+1. Fetches artifact content from the storage backend
+2. Verifies content digest matches the `StorageRef.Digest`
+3. Writes content to a shared emptyDir volume at a well-known path
+4. Reports verification status
 
-3. **Well-known path structure**: External results are available at:
-   ```
-   /tekton/results/external/<task-name>/<result-name>
-   ```
+```yaml
+# Injected by controller (not written by users)
+initContainers:
+  - name: tekton-artifact-fetch
+    image: gcr.io/tekton-releases/artifact-fetcher:latest
+    args:
+      - --artifacts=build/images:oci://registry.example.com/tekton/artifacts:tag
+      - --verify-digest=sha256:abc123...
+      - --output-dir=/tekton/artifacts/external
+    volumeMounts:
+      - name: tekton-artifacts
+        mountPath: /tekton/artifacts/external
+```
 
-**Why always use init containers (no size threshold):**
+Content is available to Steps at the paths resolved by `$(inputs.<name>.path)`:
+```
+/tekton/artifacts/inputs/<artifact-name>/          # for declarative API
+/tekton/artifacts/inputs/<artifact-name>/provenance.json  # provenance metadata
+```
 
-- **Simplicity**: One code path instead of branching based on size
-- **Consistency**: All external results behave the same way
-- **No tuning**: No threshold to configure or optimize
-- **Clear mental model**: `type: external` = file-based, `type: string` = inline
-- **Future-proof**: Results can grow without changing behavior
+This parallels the trust model from TEP-0139: the init container acts as
+the "download + verify" trusted step, ensuring content integrity before any
+user Steps execute. The key difference from TEP-0139 is that these are init
+containers (not injected Steps), so they don't appear in the Step list and
+don't consume Step-level resources.
 
-If a result is small enough to be inline, it should use `type: string`.
-Declaring `type: external` is an explicit signal that file-based handling
-is appropriate.
+### Pipeline-Level Artifact Declarations
 
-### Pipeline-Level Result Declarations
-
-Pipelines can declare results that reference Task results. When a Task result
-is declared as `type: external`, the Pipeline result can also be declared as
-external:
+Pipelines can declare their own inputs and outputs, enabling artifact
+passing across Pipeline boundaries and surfacing Task artifacts at the
+Pipeline level:
 
 ```yaml
 apiVersion: tekton.dev/v1
@@ -514,276 +834,371 @@ kind: Pipeline
 metadata:
   name: build-and-sign
 spec:
-  results:
-    - name: images
-      type: external  # Pipeline result is also external
-      value: $(tasks.build.results.IMAGES)
-    - name: digest
-      type: string    # Inline result from task
-      value: $(tasks.build.results.digest)
+  # Pipeline-level artifact declarations
+  artifacts:
+    inputs:
+      - name: source
+        description: Source code (passed from an outer Pipeline or PipelineRun)
+    outputs:
+      - name: images
+        from: tasks.build.outputs.images
+      - name: signatures
+        from: tasks.sign.outputs.signatures
   tasks:
     - name: build
       taskRef:
         name: build-images
+      artifacts:
+        inputs:
+          - name: source
+            from: artifacts.inputs.source  # from Pipeline-level input
+    - name: sign
+      taskRef:
+        name: sign-images
+      artifacts:
+        inputs:
+          - name: images
+            from: tasks.build.outputs.images
 ```
 
-**Behavior:**
-
-- When a Pipeline result references an external Task result with
-  `type: external`, the PipelineRun status stores the same reference
-  (no re-upload needed).
-
-- When a Pipeline result references an external Task result with
-  `type: string` (inline), the controller fetches the external content
-  and stores it inline in the PipelineRun status (subject to size limits).
-
-- Attempting to declare a Pipeline result as `type: string` when referencing
-  a very large external Task result will fail with a clear error message.
-
-### Integration with External Tools and Services
-
-External results must be accessible not only to the Tekton controller but
-also to other tools and services in the Tekton ecosystem that consume
-TaskRun results.
-
-**Tekton Chains Integration:**
-
-[Tekton Chains](https://github.com/tektoncd/chains) monitors TaskRun
-completions and creates attestations based on results. For external results:
-
-1. Chains must have access to the same storage credentials as the controller
-2. Chains uses the `ResultRef` to fetch content for attestation
-3. The digest in the reference can be included in the attestation without
-   fetching the full content (for provenance)
-
-**Credential Sharing:**
-
-Storage credentials must be available to:
-- TaskRun pods (for uploading results via entrypoint)
-- Tekton Pipelines controller (for resolving results in downstream tasks)
-- Tekton Chains controller (for creating attestations)
-- Tekton Results (for long-term storage and querying)
-- Any other tools that need to access result content
-
-The recommended approach is to use a shared Secret that all components
-can access, or workload identity (IRSA, GKE Workload Identity) where
-credentials are derived from ServiceAccount annotations.
+**PipelineRun artifact inputs** can be provided when triggering a run:
 
 ```yaml
-apiVersion: v1
-kind: Secret
+apiVersion: tekton.dev/v1
+kind: PipelineRun
 metadata:
-  name: tekton-results-storage-creds
-  namespace: tekton-pipelines
-  annotations:
-    # Used by controller, chains, and entrypoint
-    tekton.dev/credential-scope: "result-storage"
-type: Opaque
-data:
-  # Credentials shared across components
-  access-key: ...
-  secret-key: ...
+  name: my-build-run
+spec:
+  pipelineRef:
+    name: build-and-sign
+  artifacts:
+    inputs:
+      - name: source
+        values:
+          - uri: "pkg:generic/source@abc123"
+            digest:
+              sha256: "abc123..."
+            ref:
+              backend: oci
+              location: "registry.example.com/sources:abc123"
+              digest: "sha256:abc123..."
 ```
+
+When the referenced Task artifacts have storage references, the Pipeline
+output artifacts carry the same references (no re-upload). The PipelineRun
+status includes the full artifact provenance chain.
+
+### OCI Artifact Grouping per PipelineRun
+
+When using an OCI registry backend, individual artifacts from a PipelineRun
+can be difficult to browse. This section describes an optional grouping
+strategy using OCI referrers (subject/refers-to relationships).
+
+**Proposed structure:**
+
+```
+PipelineRun reference artifact (index)
+├── TaskRun "build" reference artifact
+│   ├── artifact: images (content layer)
+│   └── artifact: build-log (content layer)
+├── TaskRun "sign" reference artifact
+│   └── artifact: signatures (content layer)
+└── TaskRun "attest" reference artifact
+    └── artifact: attestation (content layer)
+```
+
+The PipelineRun controller creates a root OCI artifact on PipelineRun
+initialization. Each TaskRun's artifacts are attached as referring artifacts.
+This enables:
+
+- **Browsability**: Users can discover all artifacts from a PipelineRun
+  starting from a single reference
+- **Cache-friendliness**: Content-addressable layers enable OCI cache hits
+- **Cleanup**: Deleting the root artifact cascades to all related artifacts
+
+This feature is **optional** and only active when using the OCI backend with
+`oci.groupByPipelineRun: "true"` in the configuration.
+
+### Integration with Tekton Chains
+
+Tekton Chains monitors TaskRun completions and creates SLSA provenance
+attestations. The storage reference design directly addresses a critical
+concern: **provenance explosion**.
+
+**Problem**: If Chains records full artifact content in attestations (as it
+currently does for results), large artifacts would cause:
+- Massive attestation documents
+- Rekor storage issues (as seen with SBOMs)
+- Duplication: same content in one Task's output and another's input
+
+**Solution with storage references:**
+
+Chains can include only the **reference** (URI + digest) in the attestation,
+not the full content:
+
+```json
+{
+  "subject": [
+    {
+      "name": "pkg:docker/myapp@sha256:abc123",
+      "digest": {"sha256": "abc123..."},
+      "annotations": {
+        "tekton.dev/storage-ref": "oci://registry.example.com/tekton/artifacts:tag"
+      }
+    }
+  ]
+}
+```
+
+This keeps attestations small and verifiable. Anyone with the digest can
+fetch and verify the full content from external storage independently.
+
+**Chains integration requirements:**
+1. Chains must recognize `StorageRef` in artifact values
+2. Chains records `Uri` + `Digest` (already does this for TEP-0147 artifacts)
+3. Chains does NOT fetch and inline full content for externally stored artifacts
+4. Chains MAY include `StorageRef.Location` as an annotation for discoverability
+
+### Integration with Tekton Results and UIs
+
+**Tekton Results** (long-term storage and querying):
+- Results API stores `StorageRef` as metadata
+- Optionally fetches and archives artifact content for long-term retention
+- Query by artifact digest enables cross-pipeline correlation
+
+**Downstream UIs** (Dashboard, third-party):
+- UIs display artifact metadata from TaskRun status (URI, digest, size)
+- For full content viewing, UIs resolve the `StorageRef` and fetch on demand
+- Inline artifacts display directly (no fetch needed)
+- The `size` field enables UIs to show content size without fetching
+
+**Archivista and other storage backends:**
+- Chains integration with [Archivista](https://github.com/tektoncd/chains/pull/1316)
+  works as before — it stores the attestation, which now contains references
+  rather than full content
+- No-op for Archivista: it depends on Chains's provenance, not on raw content
 
 ### Storage Provider Interface
 
 ```go
-package resultstorage
+package artifactstorage
 
 import (
     "context"
     "io"
+
+    v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )
 
-// ResultRef contains the reference to an externally stored result
-type ResultRef struct {
-    Backend     string `json:"backend"`
-    Bucket      string `json:"bucket,omitempty"`
-    Key         string `json:"key"`
-    Digest      string `json:"digest"`
-    Size        int64  `json:"size"`
-    ContentType string `json:"contentType,omitempty"`
-}
-
-// Provider defines the interface for result storage backends
+// Provider defines the interface for artifact storage backends.
 type Provider interface {
-    // Name returns the provider identifier (s3, gcs, oci, azure, pvc)
+    // Name returns the provider identifier (oci, s3, gcs, azure, pvc).
     Name() string
 
-    // Store writes result content and returns a reference
-    Store(ctx context.Context, key string, content io.Reader, opts StoreOptions) (*ResultRef, error)
+    // Store uploads artifact content and returns a storage reference.
+    // The provider computes the digest during upload and returns it
+    // in the StorageRef.
+    Store(ctx context.Context, opts StoreOptions, content io.Reader) (*v1.StorageRef, error)
 
-    // Fetch retrieves result content by reference
-    Fetch(ctx context.Context, ref *ResultRef) (io.ReadCloser, error)
+    // Fetch retrieves artifact content by storage reference.
+    // Returns an error if the content digest does not match.
+    Fetch(ctx context.Context, ref *v1.StorageRef) (io.ReadCloser, error)
 
-    // Delete removes stored result (for garbage collection)
-    Delete(ctx context.Context, ref *ResultRef) error
+    // Delete removes stored artifact content.
+    Delete(ctx context.Context, ref *v1.StorageRef) error
 
-    // Exists checks if a result exists
-    Exists(ctx context.Context, ref *ResultRef) (bool, error)
+    // Exists checks if artifact content exists.
+    Exists(ctx context.Context, ref *v1.StorageRef) (bool, error)
 }
 
-// StoreOptions contains options for storing a result
+// StoreOptions contains metadata for storing an artifact.
 type StoreOptions struct {
+    // Namespace of the TaskRun
+    Namespace string
+    // TaskRun name
+    TaskRun string
+    // PipelineRun name (if part of a pipeline)
+    PipelineRun string
+    // Artifact name
+    ArtifactName string
+    // Content type hint
     ContentType string
-    Metadata    map[string]string
+    // Additional metadata
+    Labels map[string]string
 }
 
-// ProviderConfig contains configuration for initializing a provider
+// ProviderConfig contains configuration for initializing a provider.
 type ProviderConfig struct {
     Backend     string
-    Credentials CredentialsSource
     Options     map[string]string
+    Credentials CredentialsSource
 }
 
-// CredentialsSource defines where to get storage credentials
+// CredentialsSource defines where to get storage credentials.
 type CredentialsSource struct {
+    // SecretRef references a Kubernetes Secret
     SecretRef *SecretKeySelector
-    // Future: ServiceAccount for workload identity
+    // ServiceAccountName for workload identity (IRSA, GKE WI)
+    ServiceAccountName string
+}
+
+// SecretKeySelector identifies a Secret and key
+type SecretKeySelector struct {
+    Name string
+    Key  string
 }
 ```
 
 ### Supported Backends
 
-**Phase 1 (MVP):**
-- S3 (via `gocloud.dev/blob/s3blob`)
-- OCI Registry (via `oras.land/oras-go/v2`)
-- PVC (local storage, no external infrastructure needed)
+**Phase 1 (Alpha):**
+- **OCI Registry** (via `oras.land/oras-go/v2`) — primary backend, compatible
+  with Konflux CI's OCI-based trusted artifacts pattern
+- **S3** (via `gocloud.dev/blob/s3blob`) — compatible with MinIO for
+  on-premises deployments
+- **PVC** — no external infrastructure needed, suitable for single-cluster
+  development
 
-**Phase 2:**
-- GCS (via `gocloud.dev/blob/gcsblob`)
-- Azure Blob (via `gocloud.dev/blob/azureblob`)
+**Phase 2 (Beta):**
+- **GCS** (via `gocloud.dev/blob/gcsblob`)
+- **Azure Blob** (via `gocloud.dev/blob/azureblob`)
 
-**Phase 3:**
-- Custom (webhook-based for extensibility)
+**OCI Backend Details:**
+
+The OCI backend is the recommended default, as it aligns with:
+- Konflux CI's production trusted artifacts ([ADR-0036](https://github.com/konflux-ci/architecture/blob/main/ADR/0036-trusted-artifacts.md))
+  using `create-trusted-artifact` / `use-trusted-artifact` steps
+- Tekton Chains' existing OCI storage for attestations
+- Container image registries already present in Kubernetes clusters
+
+Artifacts are stored as OCI artifacts with:
+- Content as a single layer (content-addressable by digest)
+- Artifact metadata as annotations
+- Tags following the configured `tagPattern`
 
 ### Garbage Collection
 
-External results consume storage that should be cleaned up when no longer
-needed. This section describes the garbage collection strategy.
+External artifacts consume storage that should be cleaned up. Approaches
+(in order of implementation priority):
 
-**Note:** Garbage collection is considered a **nice-to-have for initial
-implementation**. The MVP can rely on external storage lifecycle policies
-(e.g., S3 bucket lifecycle rules) or manual cleanup. Automated garbage
-collection can be added in a later phase.
+1. **Storage lifecycle policies** (MVP): Document that operators should
+   configure backend-native TTL policies (S3 lifecycle rules, OCI tag
+   expiration, etc.)
 
-**Proposed approaches (for future implementation):**
-
-1. **Finalizer-based cleanup**: Add a finalizer to TaskRuns with external
-   results. When the TaskRun is deleted, the controller deletes the
-   associated external result objects before removing the finalizer.
+2. **Finalizer-based cleanup** (Phase 2): Add a finalizer to TaskRuns with
+   external artifacts. On deletion, the controller removes associated
+   artifacts from external storage.
 
    ```yaml
    metadata:
      finalizers:
-       - results.tekton.dev/external-cleanup
+       - artifacts.tekton.dev/external-cleanup
    ```
 
-2. **Background garbage collector**: A separate controller or CronJob that:
-   - Lists all external result references in storage
-   - Checks if the corresponding TaskRun still exists
-   - Deletes orphaned results after a grace period
-
-3. **TTL-based expiration**: Configure storage backend with automatic
-   expiration (e.g., S3 lifecycle policies, OCI tag expiration). Results
-   are automatically deleted after a configurable period.
-
-4. **Integration with Tekton Results**: When Tekton Results is deployed,
-   external result references can be migrated to Results storage before
-   TaskRun deletion, preserving data for historical queries.
-
-**Recommendation for MVP:** Document that operators should configure
-storage lifecycle policies for automatic cleanup, and implement
-finalizer-based cleanup in Phase 2 or 3.
+3. **Integration with Tekton Results** (Phase 3): When Tekton Results is
+   deployed, artifact references can be preserved in Results storage before
+   TaskRun deletion, maintaining queryability without retaining all content.
 
 ## Design Evaluation
 
 ### Reusability
 
-This proposal builds on existing patterns:
-- URI scheme pattern from [tekton-caches](https://github.com/openshift-pipelines/tekton-caches)
-- Storage abstraction from [go-cloud/blob](https://github.com/google/go-cloud)
-- Artifact pattern from [Argo Workflows](https://argo-workflows.readthedocs.io/en/latest/walk-through/artifacts/)
+This proposal extends TEP-0147 Phase 1 (implemented, alpha) rather than
+creating a new system. The artifact provenance structure, API paths, and
+variable substitution syntax are all reused directly. The storage provider
+interface can be reused by Tekton Chains and Tekton Results.
 
-The storage provider interface can be reused by other Tekton components
-(e.g., Tekton Results project, Tekton Chains).
+The OCI backend aligns with Konflux CI's production pattern, enabling
+compatibility with existing `create-trusted-artifact` / `use-trusted-artifact`
+StepActions.
 
 ### Simplicity
 
-**Current Experience (without feature):**
-- Users hit 4KB/12KB limits unexpectedly
-- Workarounds: use Workspaces (requires PVC), split results, compress data
-- Sidecar logs approach adds overhead to every TaskRun
+**For Task authors**: No change to the artifact reporting API. Steps still
+write to `$(step.artifacts.path)` in the same JSON format. If external
+storage is configured, the entrypoint handles upload transparently.
 
-**With Feature:**
-- Declare `type: external` on results that may be large
-- Configure storage backend once at cluster level
-- Same result writing API (`echo > $(results.name.path)`)
-- Same result reference syntax (`$(tasks.x.results.y)`)
+**For Pipeline authors**: No change to variable substitution syntax. Artifacts
+from upstream Tasks are consumed via `$(tasks.name.outputs.artifact)` as
+before.
+
+**For operators**: Single ConfigMap (`config-artifact-storage`) to configure
+the storage backend. Familiar pattern from Tekton Chains configuration.
 
 ### Flexibility
 
 - Pluggable backends allow operators to use existing infrastructure
-- OCI registry backend works in environments with only registry access
-- PVC backend (Phase 3) requires no external infrastructure
-- Per-result opt-in means users control which results use external storage
+- Three storage modes (inline, external, reference-only) cover all use cases
+- Per-namespace and per-PipelineRun configuration enables multi-tenant setups
+- OCI artifact grouping is optional for teams that want browsability
 
 ### Conformance
 
-- Extends existing Results API with new type
-- Does not require understanding Kubernetes internals
-- API changes are additive and backward compatible
-- Results syntax remains consistent
+- Extends existing TEP-0147 API with backward-compatible additions
+- Variable substitution syntax unchanged
+- Results API unchanged (artifacts and results are separate concerns)
+- Feature flag gated for gradual adoption
 
 ### User Experience
 
-**Task Authors:**
-- Add `type: external` to large result declarations
-- Same file-based result writing API
+**What changes:**
+- Operators configure `config-artifact-storage` (one-time setup)
+- Task authors declare `spec.artifacts.inputs/outputs` and use
+  `$(inputs.name.path)` / `$(outputs.name.path)` variables
+- Pipeline authors connect Tasks with `artifacts.inputs[].from`
 
-**Pipeline Authors:**
-- No changes - same `$(tasks.x.results.y)` syntax
+**What stays the same:**
+- `$(step.artifacts.path)` API (TEP-0147 Phase 1 backward compat)
+- `$(tasks.name.outputs.artifact)` syntax (provenance metadata)
+- Artifact JSON format (`inputs`/`outputs` with `uri`/`digest`)
+- TaskRun status structure (extended, not replaced)
 
-**Operators:**
-- Configure `config-result-storage` ConfigMap once
-- Manage storage backend credentials
+**Progressive adoption path:**
+1. **Today**: Tasks use `$(step.artifacts.path)` to write provenance JSON
+   manually (TEP-0147 Phase 1)
+2. **With this TEP**: Tasks can declare `spec.artifacts` and write content
+   to `$(outputs.name.path)` — Tekton handles storage, digest, provenance
+3. **Migration**: Existing Tasks continue to work; new Tasks use the
+   declarative API for a simpler, safer experience
 
 ### Performance
 
-**Positive Impact:**
-- No sidecar container overhead on every TaskRun
-- Large results don't bloat etcd/API server
+**Positive:**
+- No sidecar container overhead (unlike TEP-0127)
+- Large artifacts don't bloat etcd/API server
+- OCI content-addressable storage enables caching
 
-**Potential Impact:**
-- Network latency when fetching external results for downstream tasks
-- Storage backend availability affects Pipeline reliability
+**Potential:**
+- Network latency when fetching artifacts for downstream Tasks
+- Init container startup time (~1-2s)
 
 **Mitigations:**
-- Content-addressable references enable caching
-- Parallel fetching for multiple external results in a single init container
-- Init container startup overhead is minimal compared to result fetch time
+- Parallel fetching for multiple artifacts in a single init container
+- OCI layer caching when clusters have caching proxies configured
+- Inline mode for small artifacts avoids any latency
 
 ### Risks and Mitigations
 
-| Risk                                    | Mitigation                                                         |
-|-----------------------------------------|--------------------------------------------------------------------|
-| Storage backend unavailable             | Graceful degradation with clear error messages; retry with backoff |
-| Credential management complexity        | Support workload identity (IRSA, GKE WI); clear documentation      |
-| Orphaned results after TaskRun deletion | Garbage collection via finalizers or async cleanup job             |
-| Large result fetching latency           | Caching layer; parallel fetch; optional streaming                  |
+| Risk | Mitigation |
+|------|------------|
+| Storage backend unavailable | Clear error messages; retry with backoff; inline fallback for small content |
+| Credential management complexity | Support workload identity (IRSA, GKE WI); per-SA configuration |
+| Orphaned artifacts | Storage lifecycle policies (MVP); finalizer cleanup (Phase 2) |
+| Provenance explosion in Chains | Reference-based design: Chains records URI + digest, not content |
+| Breaking TEP-0147 Phase 1 | All additions are optional fields; existing behavior unchanged |
 
 ### Drawbacks
 
-1. **External Infrastructure Required**: Unlike sidecar logs, this requires
-   additional infrastructure (S3 bucket, registry, etc.)
+1. **Infrastructure requirement**: External storage requires additional
+   infrastructure (OCI registry, S3 bucket, etc.) — mitigated by PVC
+   backend for development.
 
-2. **Credential Management**: Storage credentials must be configured and
-   maintained
+2. **Credential management**: Storage credentials must be configured —
+   mitigated by workload identity support and per-SA configuration.
 
-3. **Network Dependency**: Result resolution depends on network access to
-   storage backend
-
-4. **Debugging Complexity**: Results are not directly visible in TaskRun status
+3. **Debugging complexity**: Artifact content not directly visible in
+   TaskRun status — mitigated by inline mode for small artifacts, and
+   `size` + `digest` metadata in status for troubleshooting.
 
 ## Alternatives
 
@@ -792,102 +1207,142 @@ The storage provider interface can be reused by other Tekton components
 **Approach**: Inject a sidecar container that monitors result files and emits
 them via stdout; controller reads from pod logs.
 
-**Why Not Chosen**:
-- Creates sidecar on EVERY TaskRun (resource overhead)
+**Why not chosen**:
+- Sidecar on EVERY TaskRun (resource overhead)
 - ~3 second startup time increase per TaskRun
-- Cluster-wide only, no per-Task opt-in
 - Results still end up in TaskRun status (~1.5MB CRD limit)
-- Controller needs pod logs access (security concern)
-- [Issue #8448](https://github.com/tektoncd/pipeline/issues/8448) requests selective enablement
+- No artifact provenance integration
+- [Issue #8448](https://github.com/tektoncd/pipeline/issues/8448) requests
+  selective enablement
+
+### TEP-0139: Injected Trusted Steps with PVC
+
+**Approach**: Inject 4 Steps (digest, upload, download, verify) into TaskRun
+Pods, using a shared PVC Workspace for artifact storage.
+
+**Why not chosen as-is**:
+- Injected Steps are visible overhead (4 extra containers per Task)
+- PVC-only storage limits artifact size to node disk / PVC capacity
+- PVC requires ReadWriteMany for parallel Tasks (not universally available)
+- No cross-cluster artifact sharing
+- Artifact Workspace auto-provisioning adds controller complexity
+- Tarball format (`<digest>.tgz`) is opaque in OCI registries
+
+**What we adopt from TEP-0139**:
+- Declarative Artifact API (`spec.artifacts.inputs/outputs`)
+- Pipeline-level artifact binding
+- Chain of trust via digest verification
+- Artifact provenance in TaskRun status
+
+**Where we differ**:
+- Entrypoint + init container instead of injected Steps (transparent)
+- External storage backends (OCI, S3, GCS) instead of PVC-only
+- Content stored as-is, not as tarballs
+
+### Standalone External Results (Original TEP-0164)
+
+**Approach**: Introduce `type: external` as a new Result type, separate from
+TEP-0147 artifacts.
+
+**Why not chosen**:
+- Creates a parallel system alongside TEP-0147 artifacts
+- No artifact provenance integration (URI, digest)
+- Doesn't address TEP-0139 trusted artifacts convergence
+- Risk of duplicating content in Chains attestations (provenance explosion)
+- @arewm's review correctly identified the need for reference-based design
+  and TEP-0139 convergence
 
 ### ConfigMaps per TaskRun
 
-**Approach**: Create a ConfigMap for each TaskRun to store results, then
-copy to TaskRun status.
+**Approach**: Create a ConfigMap for each TaskRun to store results.
 
-**Why Not Chosen**:
-- RBAC complexity (controller needs permission to create roles/bindings)
+**Why not chosen**:
 - Still limited to ~1.5MB per ConfigMap
-- API server load (3+ requests per TaskRun)
-- Cleanup complexity
-
-### Custom CRD for Results
-
-**Approach**: Store results in dedicated TaskRunResult CRD.
-
-**Why Not Chosen**:
-- Still subject to ~1.5MB CRD limit
-- Introduces new resource type to manage
-- Additional API server load
+- RBAC complexity
+- API server load
 
 ### Workspaces Only
 
-**Approach**: Document that large data should use Workspaces, no changes needed.
+**Approach**: Document that large data should use Workspaces.
 
-**Why Not Chosen**:
-- Requires separate storage infrastructure
+**Why not chosen**:
 - Changes how users think about results vs files
-- Requires Task modifications to read from workspace paths
-- Breaks task library patterns
+- Requires Task modifications
+- No provenance/trust chain
 - Incompatible with no-code/low-code abstractions
 
 ## Implementation Plan
 
 ### Phase 1: Core Infrastructure (Alpha)
 
-1. Define `ResultRef` types in API
-2. Implement `Provider` interface
-3. Implement S3 provider using `gocloud.dev/blob`
-4. Implement OCI provider using ORAS
-5. Add `config-result-storage` ConfigMap handling
-6. Modify entrypoint to upload external results
-7. Feature flag: `enable-external-results: "true"`
-8. Modify TaskRun reconciler to handle external result references
-9. Init container injection for downstream result resolution
-10. Implement result resolution for PipelineRun
-11. Validation: reject `type: external` when storage not configured
-12. E2E tests with S3 and OCI backends
-13. Document storage lifecycle policies for cleanup (defer automated GC)
+1. **Declarative Artifact API**: Add `spec.artifacts.inputs/outputs` to
+   Task spec with validation
+2. **Artifact path variables**: Implement `$(inputs.name.path)`,
+   `$(outputs.name.path)`, `$(inputs.name.uri)`, `$(inputs.name.digest)`
+3. Extend `ArtifactValue` and `Artifact` types with `StorageRef`, `Size`,
+   `Inline` fields
+4. Define `Provider` interface
+5. Implement OCI provider using ORAS (Konflux-compatible)
+6. Implement S3 provider using `gocloud.dev/blob`
+7. Implement PVC provider
+8. Add `config-artifact-storage` ConfigMap handling
+9. Modify entrypoint to upload artifacts from `$(outputs.name.path)` with
+   automatic digest computation
+10. Init container injection for downloading artifacts to
+    `$(inputs.name.path)` with digest verification
+11. Feature flag: `enable-artifact-storage: "true"` (extends existing
+    `enable-artifacts`)
+12. E2E tests with OCI and S3 backends
+13. Document storage lifecycle policies for cleanup
 
-### Phase 2: Additional Backends and Features (Beta)
+### Phase 2: Extended Features (Beta)
 
-1. Implement GCS provider
-2. Implement Azure Blob provider
-3. Implement PVC provider
-4. Namespace-level configuration overrides (per TEP-0085 patterns)
-5. Garbage collection via finalizers
-6. Pipeline-level external result declarations
-7. Tekton Chains integration testing
-8. Promote to beta
+1. **Pipeline-level artifact binding**: `artifacts.inputs[].from` syntax
+   with implicit DAG edges
+2. **Pipeline-level artifact declarations**: Pipeline `spec.artifacts`
+   inputs/outputs
+3. GCS and Azure Blob providers
+4. Namespace-level configuration overrides
+5. Per-PipelineRun configuration via annotations
+6. OCI artifact grouping per PipelineRun
+7. Garbage collection via finalizers
+8. Tekton Chains integration (reference-based attestations)
+9. Promote to beta
 
 ### Phase 3: Production Ready (Stable)
 
-1. Caching layer for frequently accessed results
-2. Metrics and observability
+1. Caching layer for OCI artifacts
+2. Metrics and observability (upload/download latency, storage usage)
 3. Integration with Tekton Results project
-4. Background garbage collector for orphaned results
+4. Background garbage collector for orphaned artifacts
 5. Promote to stable
 
 ### Test Plan
 
+- Unit tests for `spec.artifacts` validation and variable substitution
 - Unit tests for each storage provider
+- Unit tests for `ArtifactValue` extension backward compatibility
+- Integration tests for declarative artifact binding between Tasks
 - Integration tests with mock storage
-- E2E tests with real storage backends (S3/MinIO, OCI registry)
-- Performance benchmarks comparing inline vs external results
-- Failure mode testing (storage unavailable, credentials expired, etc.)
+- E2E tests with real backends (OCI registry via `zot`, S3 via MinIO)
+- E2E tests verifying digest verification catches tampering
+- E2E tests for Pipeline-level artifact passing
+- Performance benchmarks for upload/download latency
+- Backward compatibility tests with TEP-0147 Phase 1 artifacts
 
 ### Infrastructure Needed
 
-- CI/CD access to test storage backends (MinIO for S3, local registry for OCI)
+- CI/CD access to OCI registry (e.g., `zot` or local distribution registry)
+- CI/CD access to S3-compatible storage (MinIO)
 - Documentation updates for configuration
-- Example Tasks demonstrating external results
 
 ### Upgrade and Migration Strategy
 
-- Feature is opt-in via result type declaration
+- Feature is opt-in via ConfigMap configuration and feature flag
 - No migration needed for existing Tasks/Pipelines
+- Existing TEP-0147 Phase 1 artifacts continue to work unchanged
 - Feature flag allows gradual rollout
-- Existing inline results continue to work unchanged
+- Inline results continue to work as before
 
 ### Implementation Pull Requests
 
@@ -895,15 +1350,17 @@ copy to TaskRun status.
 
 ## References
 
+- [TEP-0147: Tekton Artifacts Phase 1](https://github.com/tektoncd/community/blob/main/teps/0147-tekton-artifacts-phase1.md) — Foundation this TEP extends
+- [TEP-0139: Trusted Artifacts](https://github.com/tektoncd/community/blob/main/teps/0139-trusted-artifacts.md) — Trust chain requirements this TEP implements
 - [TEP-0085: Per-Namespace Controller Configuration](https://github.com/tektoncd/community/blob/main/teps/0085-per-namespace-controller-configuration.md)
-- [TEP-0086: Changing the Way Result Parameters are Stored](https://github.com/tektoncd/community/blob/main/teps/0086-changing-the-way-result-parameters-are-stored.md)
-- [TEP-0127: Larger Results via Sidecar Logs](https://github.com/tektoncd/community/blob/main/teps/0127-larger-results-via-sidecar-logs.md)
+- [TEP-0127: Larger Results via Sidecar Logs](https://github.com/tektoncd/community/blob/main/teps/0127-larger-results-via-sidecar-logs.md) — Alternative approach
+- [Konflux CI Trusted Artifacts (ADR-0036)](https://github.com/konflux-ci/architecture/blob/main/ADR/0036-trusted-artifacts.md) — Production OCI-based pattern
 - [Issue #4012: Changing the way Result Parameters are stored](https://github.com/tektoncd/pipeline/issues/4012)
 - [Issue #4808: Results, TerminationMessage and Containers](https://github.com/tektoncd/pipeline/issues/4808)
+- [Issue #6326: Artifact provenance feature request](https://github.com/tektoncd/pipeline/issues/6326)
 - [Issue #8448: Enable larger results without a sidecar on every TaskRun](https://github.com/tektoncd/pipeline/issues/8448)
 - [Argo Workflows Artifacts](https://argo-workflows.readthedocs.io/en/latest/walk-through/artifacts/)
-- [tekton-caches: Pluggable storage backends](https://github.com/openshift-pipelines/tekton-caches)
-- [go-cloud/blob: Multi-cloud storage abstraction](https://github.com/google/go-cloud/tree/master/blob)
 - [ORAS: OCI Registry As Storage](https://oras.land/)
+- [go-cloud/blob: Multi-cloud storage abstraction](https://github.com/google/go-cloud/tree/master/blob)
 - [Tekton Results Project](https://github.com/tektoncd/results)
 - [Tekton Chains](https://github.com/tektoncd/chains)

--- a/teps/0164-larger-results-via-external-storage.md
+++ b/teps/0164-larger-results-via-external-storage.md
@@ -598,10 +598,20 @@ data:
   inline-threshold: "1024"
 
   # OCI Registry configuration
+  # This repository is used for intermediate artifact staging (task-to-task
+  # passing). When oci.attachReferrers is enabled and a pipeline has a
+  # buildOutput artifact, referrers are pushed to the BUILD OUTPUT's
+  # repository (not this one) — see "Same-repository constraint" in the
+  # OCI Referrers section.
   oci.repository: "registry.example.com/tekton/artifacts"
   oci.credentialsSecret: "tekton-artifact-oci-creds"
 
-  # Tag pattern for storing artifacts
+  # Attach output artifacts as OCI referrers to buildOutput artifacts.
+  # Referrers are pushed to the build output's repository (same-repo
+  # requirement per OCI Distribution Spec). Default: "true".
+  oci.attachReferrers: "true"
+
+  # Tag pattern for storing artifacts in oci.repository
   # Available variables: {{namespace}}, {{pipelinerun}}, {{taskrun}}, {{artifact}}
   oci.tagPattern: "{{namespace}}-{{taskrun}}-{{artifact}}"
 ```
@@ -1032,6 +1042,63 @@ The controller attaches artifacts as referrers **by default** when using
 the OCI backend. This can be disabled with
 `oci.attachReferrers: "false"` in the configuration.
 
+**Same-repository constraint**
+
+The [OCI Distribution Spec](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers)
+requires that referrers live in the **same repository** as their subject:
+
+> Each descriptor is of an image manifest or index **in the same `<name>`
+> namespace** with a `subject` field that specifies the value of `<digest>`.
+
+This has a critical implication: **artifact staging and referrer attachment
+are two distinct operations with potentially different destination
+repositories.**
+
+| Operation | When | Destination | Purpose |
+|-----------|------|-------------|----------|
+| Artifact staging | During the run | `oci.repository` (ConfigMap) | Task-to-task data passing |
+| Referrer attachment | After the run | Build output's repository | Supply chain graph |
+
+When a pipeline builds a container image and pushes it to
+`ghcr.io/org/project`, the staging repository (e.g.
+`ghcr.io/org/project/artifacts`) is used for intermediate artifact
+passing. But when attaching referrers, the controller must push the
+referrer manifests into `ghcr.io/org/project` — the **image's repository**
+— not the staging repository.
+
+```
+# Image build: two repos involved
+ghcr.io/org/project/artifacts   ← staging (task-to-task passing)
+ghcr.io/org/project             ← referrers live here (same repo as image)
+
+# Non-image build (binary tarball, RPM, etc.): one repo
+ghcr.io/org/project/artifacts   ← both staging AND referrer subject
+```
+
+The controller handles this by:
+1. **During the run**: uploading output artifacts to `oci.repository` for
+   downstream task consumption.
+2. **After the PipelineRun**: for each output artifact with a
+   `buildOutput: true` subject, pushing a referrer manifest into the
+   **subject's repository** with a `subject` descriptor pointing to the
+   build output's digest. Artifact blobs are cross-mounted (if the
+   registries support it) or re-uploaded.
+
+**Cross-registry considerations**: If the build output lives in a
+different registry than the artifact staging repo (e.g. image in
+`quay.io/org/project`, artifacts in `ghcr.io/org/artifacts`), the
+controller must have push credentials for the build output's registry.
+The ServiceAccount bound to the PipelineRun must have imagePullSecrets
+for both registries. If the controller cannot push referrers (missing
+credentials, registry doesn't support referrers), it should emit a
+warning condition on the PipelineRun rather than failing the run —
+referrer attachment is a post-run enhancement, not a pipeline-critical
+operation.
+
+For pipelines **without** a `buildOutput` artifact (e.g. binary tarball
+builds where the artifact store is the final location), referrers are
+attached within `oci.repository` itself since the subject lives there.
+
 **Alternative: OCI Index grouping per PipelineRun**
 
 For use cases requiring a single entry point per PipelineRun (rather than
@@ -1039,6 +1106,11 @@ per build output), the controller can optionally create a root OCI Index
 manifest and attach all artifacts as referrers to it. This is useful when
 there is no `buildOutput` artifact or when grouping across multiple build
 outputs is desired. Enabled with `oci.groupByPipelineRun: "true"`.
+
+The root manifest and all its referrers must reside in the **same
+repository**. When used with `buildOutput: true`, the root manifest is
+created in the build output's repository. When used without a build
+output, the root manifest is created in `oci.repository`.
 
 ### Integration with Tekton Chains
 
@@ -1317,7 +1389,9 @@ the tar to the input path, preserving the directory structure.
 **PipelineRun Grouping via OCI Referrers:**
 
 When a PipelineRun uses the OCI backend, artifacts are grouped using the
-[OCI Referrers API](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers):
+[OCI Referrers API](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers).
+All manifests in the group (root and referrers) must reside in the
+**same repository** (see [same-repository constraint](#oci-referrers-as-primary-artifact-attachment-model)).
 
 ```
 PipelineRun root manifest (OCI Index)
@@ -1520,6 +1594,7 @@ the storage backend. Familiar pattern from Tekton Chains configuration.
 | Storage backend unavailable | Clear error messages; retry with backoff; inline fallback for small content |
 | Credential management complexity | Support workload identity (IRSA, GKE WI); per-SA configuration |
 | Orphaned artifacts | Storage lifecycle policies (MVP); finalizer cleanup (Phase 2) |
+| Cross-registry referrer attachment | SA must have push credentials for build output's registry; controller emits warning (not failure) if attachment fails |
 | Provenance explosion in Chains | Reference-based design: Chains records URI + digest, not content |
 | Breaking TEP-0147 Phase 1 | All additions are optional fields; existing behavior unchanged |
 

--- a/teps/0164-larger-results-via-external-storage.md
+++ b/teps/0164-larger-results-via-external-storage.md
@@ -145,6 +145,9 @@ trusted artifacts with arbitrary size support and a declarative API**.
    without special handling.
 7. Align with **production patterns** from [Konflux CI](https://github.com/konflux-ci)'s
    OCI-based trusted artifacts ([ADR-0036](https://github.com/konflux-ci/architecture/blob/main/ADR/0036-trusted-artifacts.md)).
+8. Support **any OCI artifact as build output** — container images, binary
+   tarballs, RPMs, Helm charts, ML models — as referrer subjects for
+   artifact attachment.
 
 ### Non-Goals
 
@@ -497,6 +500,7 @@ spec:
         description: Built container image references
         buildOutput: true    # Chains treats as SLSA subject (not byProduct)
         storage: external    # hint: use external storage
+        mediaType: application/vnd.tekton.artifact.images.v1+json  # OCI layer media type
       - name: build-log
         description: Build summary log
         storage: inline      # hint: keep inline (small)
@@ -985,36 +989,56 @@ When the referenced Task artifacts have storage references, the Pipeline
 output artifacts carry the same references (no re-upload). The PipelineRun
 status includes the full artifact provenance chain.
 
-### OCI Artifact Grouping per PipelineRun
+### OCI Referrers as Primary Artifact Attachment Model
 
-When using an OCI registry backend, individual artifacts from a PipelineRun
-can be difficult to browse. This section describes an optional grouping
-strategy using OCI referrers (subject/refers-to relationships).
+Artifacts produced by a PipelineRun are attached as **OCI referrers** to
+the build output (the artifact with `buildOutput: true`) using the OCI 1.1
+[`subject` field](https://github.com/opencontainers/image-spec/blob/main/manifest.md#image-manifest-property-descriptions).
+This is the same mechanism used by cosign signatures, SBOM attachments,
+and SLSA attestations — build artifacts join the existing supply chain
+graph rather than creating a parallel convention.
 
-**Proposed structure:**
+**Referrer tree** (validated in [PoC on ghcr.io](https://github.com/vdemeester/tekton-experiments)):
 
 ```
-PipelineRun reference artifact (index)
-├── TaskRun "build" reference artifact
-│   ├── artifact: images (content layer)
-│   └── artifact: build-log (content layer)
-├── TaskRun "sign" reference artifact
-│   └── artifact: signatures (content layer)
-└── TaskRun "attest" reference artifact
-    └── artifact: attestation (content layer)
+ghcr.io/vdemeester/tekton-experiments:latest
+├── 🔐 Attestations (Tekton Chains SLSA provenance)
+├── 🔐 Signatures (Tekton Chains cosign)
+├── 🔐 SBOMs (ko-generated or syft)
+├── 📦 images-manifest.json   (from build-image task)
+├── 📦 junit-results.xml      (from run-tests task)
+└── 📦 coverage.out           (from run-tests task)
 ```
 
-The PipelineRun controller creates a root OCI artifact on PipelineRun
-initialization. Each TaskRun's artifacts are attached as referring artifacts.
+Each referrer manifest includes:
+- `artifactType`: media type identifying the artifact kind
+- `subject`: digest of the build output this artifact relates to
+- `annotations`: task name, PipelineRun name, git SHA for traceability
+
 This enables:
 
-- **Browsability**: Users can discover all artifacts from a PipelineRun
-  starting from a single reference
-- **Cache-friendliness**: Content-addressable layers enable OCI cache hits
-- **Cleanup**: Deleting the root artifact cascades to all related artifacts
+- **Discovery**: `oras discover <image>` or `cosign tree <image>` shows
+  the full supply chain graph — signatures, attestations, SBOMs, and build
+  artifacts in one view
+- **Ecosystem native**: same API as cosign, Chains, and SBOM tooling
+- **Non-container subjects**: the `subject` can be any OCI artifact —
+  container images, tarballs, RPMs, Helm charts, ML models (validated
+  in PoC with Go binary tarballs)
+- **History**: referrers accumulate per image digest, filterable by
+  `dev.tekton.artifact/pipelinerun` annotation
+- **Cleanup**: registry-level garbage collection of referrers
 
-This grouping is **enabled by default** when using the OCI backend. It can
-be disabled with `oci.groupByPipelineRun: "false"` in the configuration.
+The controller attaches artifacts as referrers **by default** when using
+the OCI backend. This can be disabled with
+`oci.attachReferrers: "false"` in the configuration.
+
+**Alternative: OCI Index grouping per PipelineRun**
+
+For use cases requiring a single entry point per PipelineRun (rather than
+per build output), the controller can optionally create a root OCI Index
+manifest and attach all artifacts as referrers to it. This is useful when
+there is no `buildOutput` artifact or when grouping across multiple build
+outputs is desired. Enabled with `oci.groupByPipelineRun: "true"`.
 
 ### Integration with Tekton Chains
 
@@ -1055,6 +1079,22 @@ fetch and verify the full content from external storage independently.
 2. Chains records `Uri` + `Digest` (already does this for TEP-0147 artifacts)
 3. Chains does NOT fetch and inline full content for externally stored artifacts
 4. Chains MAY include `StorageRef.Location` as an annotation for discoverability
+
+**Eliminating type hinting:**
+
+Today, Chains relies on `IMAGE_URL` and `IMAGE_DIGEST` result names (type
+hinting) to identify the build subject for SLSA attestations. This is
+fragile and requires Task authors to use specific result names.
+
+With TEP-0164, artifacts with `buildOutput: true` are explicitly marked
+as build outputs. The controller can provide this metadata directly to
+Chains, eliminating the need for type hinting. Chains would read the
+artifact declarations from the TaskRun status rather than scanning result
+names.
+
+This was validated in the [PoC](https://github.com/vdemeester/tekton-experiments):
+today, manual `IMAGE_URL`/`IMAGE_DIGEST` results are needed; with TEP-0164,
+the controller handles it.
 
 ### Integration with Tekton Results and UIs
 
@@ -1760,6 +1800,27 @@ backend.
 
 <!-- To be filled as implementation progresses -->
 
+### Proof of Concept
+
+A working proof-of-concept validating the design direction is available at
+[`vdemeester/tekton-experiments`](https://github.com/vdemeester/tekton-experiments).
+The PoC implements the OCI artifact transport pattern using existing Tekton
+primitives (StepActions with `oras`, `emptyDir` volumes) and demonstrates:
+
+- **OCI referrers**: artifacts attached to built images via OCI 1.1
+  `subject` field, visible in `cosign tree` alongside Chains attestations
+- **Non-container subjects**: binary tarballs as referrer subjects (proving
+  the pattern works for RPMs, JARs, Helm charts, etc.)
+- **SBOM generation**: syft scan with `application/spdx+json` referrer
+- **Chains integration**: SLSA attestations pushed alongside artifacts on
+  ghcr.io, with cosign signature verification
+- **Full supply chain graph**: all artifact types visible in a single
+  `oras discover` or `cosign tree` output
+
+The PoC also includes a [`future-with-tep-0164/`](https://github.com/vdemeester/tekton-experiments/tree/main/future-with-tep-0164)
+directory showing the same pipelines rewritten with the proposed
+declarative API, demonstrating ~60% fewer lines of YAML.
+
 ## References
 
 - [TEP-0147: Tekton Artifacts Phase 1](https://github.com/tektoncd/community/blob/main/teps/0147-tekton-artifacts-phase1.md) — Foundation this TEP extends
@@ -1776,3 +1837,4 @@ backend.
 - [go-cloud/blob: Multi-cloud storage abstraction](https://github.com/google/go-cloud/tree/master/blob)
 - [Tekton Results Project](https://github.com/tektoncd/results)
 - [Tekton Chains](https://github.com/tektoncd/chains)
+- [Proof of Concept: `vdemeester/tekton-experiments`](https://github.com/vdemeester/tekton-experiments) — Working PoC validating the OCI referrers pattern

--- a/teps/README.md
+++ b/teps/README.md
@@ -150,3 +150,4 @@ This is the complete list of Tekton TEPs:
 |[TEP-0161](0161-resolver-caching.md) | Resolver Caching for Task and Pipeline Resolution | proposed | 2024-06-15 |
 |[TEP-0162](0162-event-based-pruning-of-tekton-resources.md) | event based pruning of tekton resources | proposed | 2025-06-18 |
 |[TEP-0163](0163-profilebased-dynamic-compute-resources-for-steps.md) | Profile-Based Dynamic Compute Resources for Steps | proposed | 2025-09-01 |
+|[TEP-0164](0164-larger-results-via-external-storage.md) | Larger Results via External Storage with Pluggable Backends | proposed | 2026-02-09 |


### PR DESCRIPTION
# Summary

This TEP extends [TEP-0147 (Tekton Artifacts Phase 1)](https://github.com/tektoncd/community/blob/main/teps/0147-tekton-artifacts-phase1.md) with external storage backends, unifying two related problems:

1. **Larger Results** — Overcoming the 4KB/12KB termination message limits and ~1.5MB CRD size constraints
2. **Trusted Artifacts** — Establishing a chain of trust for data shared between Tasks ([TEP-0139](https://github.com/tektoncd/community/blob/main/teps/0139-trusted-artifacts.md))

## Approach

Rather than three separate TEPs solving overlapping problems, this TEP unifies **TEP-0147's provenance structure + TEP-0139's Artifact API + external storage backends** into a single design.

**Key design decisions:**

- **Extends TEP-0147** — adds `StorageRef`, `Size`, `Inline` fields to existing `ArtifactValue` type
- **Adopts TEP-0139's declarative API** — `spec.artifacts.inputs/outputs` on Tasks with `$(inputs.name.path)` / `$(outputs.name.path)` variables
- **OCI-first backend** — OCI registry is the only Phase 1 backend, leveraging existing imagePullSecrets for auth and OCI referrers for artifact attachment
- **OCI referrers as primary model** — artifacts are attached to build outputs using OCI 1.1 `subject` field, the same mechanism used by cosign signatures, SBOMs, and SLSA attestations
- **Entrypoint + init container** — transparent upload/download/verify without injected Steps or sidecars
- **Reference-based** — only URI + digest stored in TaskRun status; content lives in external storage
- **Any OCI artifact as subject** — container images, binary tarballs, RPMs, Helm charts, ML models
- **[Konflux CI](https://github.com/konflux-ci) compatible** — OCI artifact format aligned with [`build-trusted-artifacts`](https://github.com/konflux-ci/build-trusted-artifacts) ([ADR-0036](https://github.com/konflux-ci/architecture/blob/main/ADR/0036-trusted-artifacts.md))

## Proof of Concept

A working PoC validates the design: [`vdemeester/tekton-experiments`](https://github.com/vdemeester/tekton-experiments)

Implements the OCI artifact transport pattern using existing Tekton primitives and demonstrates end-to-end on ghcr.io:

```
cosign tree ghcr.io/vdemeester/tekton-experiments:latest
├── 🔐 Attestations (Tekton Chains SLSA provenance)
├── 🔐 Signatures (Tekton Chains cosign)
├── 🔐 SBOMs (ko-generated SPDX)
├── 📦 images-manifest.json (OCI referrer)
├── 📦 junit-results.xml (OCI referrer)
└── 📦 coverage.out (OCI referrer)
```

The repo also includes [non-functional YAML](https://github.com/vdemeester/tekton-experiments/tree/main/future-with-tep-0164) showing the same pipelines rewritten with the proposed declarative API (~60% fewer lines).

## OCI-First Implementation

Phase 1 focuses exclusively on OCI registry as the storage backend because:
- Every Kubernetes cluster already has access to an OCI registry
- [Konflux CI](https://github.com/konflux-ci) uses OCI for trusted artifacts in production
- Tekton Chains already stores attestations in OCI registries
- Content-addressable storage provides native deduplication and caching
- Auth reuses existing ServiceAccount imagePullSecrets — zero additional credential config in many setups

Additional backends (S3, GCS, PVC) are deferred to Phase 2 behind a `Provider` interface.

## Repository Configuration

OCI repository path is configurable at 4 levels (highest priority first):

| Priority | Source | Use Case |
|----------|--------|----------|
| 1 | PipelineRun annotations | Caller-controlled, per-invocation |
| 2 | Pipeline annotations | Pipeline author default |
| 3 | Namespace ConfigMap (TEP-0085) | Team/project isolation |
| 4 | Cluster ConfigMap | Cluster default |

## Convergence Vision

The TEP includes a [future work section](teps/0164-larger-results-via-external-storage.md#future-work-convergence-of-results-params-and-artifacts) describing the path toward unified `spec.inputs`/`spec.outputs` in a future API v2, where params, results, and artifacts converge into a single model.

## Related

- Extends: [TEP-0147](https://github.com/tektoncd/community/blob/main/teps/0147-tekton-artifacts-phase1.md) (Artifacts Phase 1 — implemented, alpha)
- Implements goals of: [TEP-0139](https://github.com/tektoncd/community/blob/main/teps/0139-trusted-artifacts.md) (Trusted Artifacts)
- Alternative to: [TEP-0127](https://github.com/tektoncd/community/blob/main/teps/0127-larger-results-via-sidecar-logs.md) (Sidecar Logs)
- References: [TEP-0085](https://github.com/tektoncd/community/blob/main/teps/0085-per-namespace-controller-configuration.md) (Per-namespace config)
- PoC: [`vdemeester/tekton-experiments`](https://github.com/vdemeester/tekton-experiments)
- Addresses: tektoncd/pipeline#4012, tektoncd/pipeline#4808, tektoncd/pipeline#6326, tektoncd/pipeline#8448

/kind tep
