### PR TITLE
Add new volunteers to tekton-vmt team

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -227,6 +227,10 @@ orgs:
         - dibyom
         - AlanGreene
         - abayer
+        - khrm
+        - waveywaves
+        - theakshaypant
+        - infernus01
         privacy: closed
       catalog.maintainers:
         description: the catalog maintainers


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

## Changes

Add 4 new volunteers to the `tekton-vmt` (Vulnerability Management Team) following the call for volunteers in #1258.

### New members

| User | Primary projects (maintainer) |
|---|---|
| @khrm | pipeline, triggers, results |
| @waveywaves | pipeline, mcp-server |
| @theakshaypant | pipelines-as-code |
| @infernus01 | pruner, pipelines-as-code |

### Updated VMT roster

**Governing Board members (existing):** @enarha, @vdemeester, @afrittoli, @dibyom, @abayer
**Other existing:** @AlanGreene
**New volunteers:** @khrm, @waveywaves, @theakshaypant, @infernus01

### Project coverage

With this update, all `tektoncd/*` projects have at least one VMT member who is a maintainer.

### Next step

Once merged, assign `tekton-vmt` as an org-level **Security Manager** (see #1258 for details).

/cc @afrittoli