### PR TITLE
Add kaushalnavneet to dashboard member

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -107,6 +107,7 @@ orgs:
     - jromero
     - jsminem
     - jtudelag
+    - kaushalnavneet
     - kgcarr
     - khalkie
     - khrm
@@ -674,6 +675,7 @@ orgs:
         - jessm12
         - ziheng
         - LyndseyBu
+        - kaushalnavneet
         privacy: closed
         repos:
           dashboard: read


### PR DESCRIPTION
Requesting addition to the Dashboard collaborators team.

I’m part of the IBM team, working with @AlanGreene on Dashboard. Adding me to the collaborators would allow issue assignment and review participation.