### PR TITLE
Remove hub.maintainers and hub.collaborators teams from org.yaml

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -335,19 +335,6 @@ orgs:
         privacy: closed
         repos:
           homebrew-tools: maintain
-      hub.maintainers:
-        description: the hub maintainers
-        maintainers:
-        - vdemeester
-        members:
-        - sthaha
-        - pratap0007
-        - PuneetPunamiya
-        - SM43
-        - vinamra28
-        privacy: closed
-        repos:
-          hub: maintain
       operator.maintainers:
         description: the operator maintainers
         maintainers:
@@ -851,23 +838,6 @@ orgs:
         privacy: closed
         repos:
           homebrew-tools: read
-      hub.collaborators:
-        description: The hub collaborators
-        maintainers:
-        - abayer
-        - afrittoli
-        - ImJasonH
-        - vdemeester
-        members:
-        - PuneetPunamiya
-        - pratap0007
-        - sthaha
-        - SM43
-        - piyush-garg
-        - vinamra28
-        privacy: closed
-        repos:
-          hub: read
       catlin.collaborators:
         description: The catlin collaborators
         maintainers:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

`tektoncd/hub` has been archived. This PR removes the corresponding
teams from `org.yaml`:

- `hub.maintainers` — 6 members, maintained access to archived repo
- `hub.collaborators` — 7 members, read access to archived repo

These teams are no longer needed since the repository is archived.