### PR TITLE
chore: propose ab-ghosh and enarha as maintainers for chains repository

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -267,6 +267,8 @@ orgs:
         description: the chains maintainers
         members:
         - anithapriyanatarajan
+        - ab-ghosh
+        - enarha
         - jkhelil
         - lcarva
         - PuneetPunamiya


### PR DESCRIPTION
@ab-ghosh  and @enarha have made significant contributions to chains repository and have clear understanding of the feature scope and CI aspects. They have been actively contributing to new feature developments, reviews, code refactoring, release automation. Hence nominating them as maintainers for chains repository.

cc: @tektoncd/chains-maintainers 