### PR TITLE
org: add Chains collaborator

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -946,6 +946,7 @@ orgs:
         - priyawadhwa
         - PuneetPunamiya
         - vdemeester
+        - waveywaves
         - wlynch
         privacy: closed
         repos:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

## Summary

Adds `waveywaves` to the `chains.collaborators` team in `org/org.yaml`. This grants the team's existing read-level access to `tektoncd/chains`.

## Public Chains contribution history

- 2 authored PRs, including 1 merged PR
- Reviewed 11 PRs through 32 review submissions
- 6 approvals and 2 change requests

## Validation

- `git diff --check`
- Parsed `org/org.yaml` and verified this change grants only `chains: read`; it does not add maintainer or admin access.

## AI assistance

AI-assisted.